### PR TITLE
Support macOS: boundary-tolerant easing goldens off the parity platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,26 @@ jobs:
       - name: CLI contract corpus
         run: ./tools/tests/cli_corpus.sh
 
+  test-macos:
+    name: Tests (macOS)
+    # No parity suites here: bit-exact parity is pinned to Linux/glibc.
+    # This job proves the port builds, tests green (with the boundary-tolerant
+    # easing assertion for Apple's libm), and honors the CLI contract on macOS.
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Unit + golden + trace tests
+        run: cargo test --release
+      - name: Build release binary
+        run: cargo build --release
+      - name: CLI contract corpus
+        run: ./tools/tests/cli_corpus.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ttfx-aarch64-apple-darwin
+          path: target/release/ttfx
+
   release-binary:
     name: Static musl binary
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -96,8 +96,11 @@ Upstream is not vendored here — the harness fetches it, because it's their cod
 
 ## Scope
 
-Linux only, built for [Omarchy](https://omarchy.org). The engine is portable and nothing
-targets a specific libc, but nothing else is tested.
+Linux and macOS. Built for [Omarchy](https://omarchy.org) originally; nothing targets a
+specific libc, and CI runs the tests and CLI corpus on both platforms. The byte-exact
+parity suites stay pinned to Linux/glibc — Apple's libm rounds a few transcendentals a
+last-ulp differently, which quantization hides in real frames but a bit-exact comparison
+would surface.
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ static INTERRUPTED: AtomicBool = AtomicBool::new(false);
 pub fn install_sigint_handler() {
     // SAFETY: signal(2) with a signal-safe handler that only stores a flag.
     unsafe {
-        libc_signal(2 /* SIGINT */, handle_sigint as usize);
+        libc_signal(2 /* SIGINT */, handle_sigint as *const () as usize);
     }
 }
 

--- a/src/utils/rng.rs
+++ b/src/utils/rng.rs
@@ -27,7 +27,8 @@ impl Rng {
 
     pub fn from_entropy() -> Self {
         let mut buf = [0u8; 8];
-        // /dev/urandom is always present on the Linux targets we support.
+        // /dev/urandom is always present on the Unix targets we support
+        // (Linux and macOS).
         use std::io::Read;
         std::fs::File::open("/dev/urandom")
             .and_then(|mut f| f.read_exact(&mut buf))

--- a/tests/easing_goldens.rs
+++ b/tests/easing_goldens.rs
@@ -54,11 +54,22 @@ fn easing_matches_python_bit_exactly() {
             offset += 8;
             let p = i as f64 / 1000.0;
             let actual = easing.ease(p);
-            // CubicBezier tolerates 1 ulp: in optimized builds LLVM
-            // const-folds some powf calls, which can differ from runtime libm
-            // by an ulp (plan.md §5.20). Quantized effect parity is unaffected.
-            let tolerance = if matches!(easing, Easing::CubicBezier(..)) { 1 } else { 0 };
-            if actual.to_bits().abs_diff(expected.to_bits()) > tolerance {
+            // Bit-exactness is only promised on the pinned parity platform
+            // (Linux/glibc — plan.md §9 "pin the parity platform"). Elsewhere
+            // the system libm rounds sin/cos/pow a last-ulp differently
+            // (measured max 2.3e-16 absolute on macOS), so other platforms get
+            // the boundary-tolerant assertion instead. Quantized effect output
+            // absorbs this either way.
+            let within_tolerance = if cfg!(target_os = "linux") {
+                // CubicBezier tolerates 1 ulp even here: in optimized builds
+                // LLVM const-folds some powf calls, which can differ from
+                // runtime libm by an ulp.
+                let tolerance = if matches!(easing, Easing::CubicBezier(..)) { 1 } else { 0 };
+                actual.to_bits().abs_diff(expected.to_bits()) <= tolerance
+            } else {
+                (actual - expected).abs() <= 1e-15
+            };
+            if !within_tolerance {
                 if mismatches < 5 {
                     eprintln!(
                         "{easing:?} at p={p}: expected {expected:?} ({:016x}), got {actual:?} ({:016x})",

--- a/tests/easing_goldens.rs
+++ b/tests/easing_goldens.rs
@@ -60,7 +60,7 @@ fn easing_matches_python_bit_exactly() {
             // (measured max 2.3e-16 absolute on macOS), so other platforms get
             // the boundary-tolerant assertion instead. Quantized effect output
             // absorbs this either way.
-            let within_tolerance = if cfg!(target_os = "linux") {
+            let within_tolerance = if cfg!(all(target_os = "linux", target_env = "gnu")) {
                 // CubicBezier tolerates 1 ulp even here: in optimized builds
                 // LLVM const-folds some powf calls, which can differ from
                 // runtime libm by an ulp.


### PR DESCRIPTION
ttfx already builds and runs correctly on macOS as-is — `signal(2)`, `/dev/urandom`, and `terminal_size` all behave, effects render, and `cli_corpus.sh` passes 19/19 untouched. The only thing standing in the way is one test.

## The problem

`tests/easing_goldens.rs` compares against CPython-generated goldens bit for bit. Apple's libm rounds `sin`/`cos`/`pow` a last ulp differently from the glibc that produced those goldens, so on macOS 176 of ~34,000 samples diverge.

I measured the actual magnitude rather than assuming: **max 2.3e-16 absolute**, i.e. one ulp at magnitude 1.0. The scarier-looking counts (`InSine` reports up to 8 ulp) are cancellation shrinking the exponent near zero, not larger error.

## The fix

`plan.md` §9 already prescribes the answer:

> pin the parity platform ... such cases get boundary-tolerant assertions rather than pretending bit-identity

So: keep the bit-exact assertion on Linux, apply a 1e-15 absolute tolerance elsewhere. **Nothing changes on the target platform** — Linux still enforces exact bits, including the existing 1-ulp CubicBezier allowance.

The parity suites (`run_suite.sh`, `tty_compare.sh`) stay Linux-only, matching the existing comment in `ci.yml` that cross-platform builds are release targets, not parity targets.

## Also in here

- A macOS CI job: tests, release build, CLI corpus. No parity suites.
- README scope section updated (it said "Linux only ... nothing else is tested").
- `install_sigint_handler` now casts through `*const ()`, silencing the new `function_casts_as_integer` warning on current toolchains.
- One comment that said "Linux targets" where it meant Unix.

44 insertions, 9 deletions, no behavior change.

## Verification

macOS 26.5, aarch64, stable toolchain: `cargo test --release` green, `cli_corpus.sh` 19/19, release binary builds and renders. Linux CI in this PR should confirm the bit-exact path is untouched.

## Why I wanted this

I built a native macOS screensaver on top of ttfx ([ttfx-macos-screensaver](https://github.com/HiroProt/ttfx-macos-screensaver)) — it links the engine as a static library through a small C shim and draws the frames with CoreText. Everything it needs is already public API, so it's a plain dependency pinned to `v0.1.2`, not a fork or a vendored copy. This patch is just the part that belongs here; entirely understandable if Linux-only is a deliberate line, in which case feel free to close it.