### PR TITLE
Boost frame throughput by over 50%

### DIFF
--- a/src/effects/rings.rs
+++ b/src/effects/rings.rs
@@ -269,7 +269,7 @@ impl Rings {
                 (motion.active_path.clone(), motion.current_coord)
             };
             let last = match active_path {
-                Some(path_id) => path_id,
+                Some(path_id) => path_id.to_string(),
                 None => "0".to_string(),
             };
             ring.character_last_ring_path.insert(id, last);

--- a/src/effects/swarm.rs
+++ b/src/effects/swarm.rs
@@ -447,11 +447,11 @@ impl Effect for Swarm {
                     let id = self.current_swarm[i];
                     let active_path_id = ctx.terminal.arena[id.0 as usize].motion.active_path.clone();
                     if let Some(path_id) = active_path_id {
-                        if path_id != self.active_swarm_area
+                        if path_id.as_ref() != self.active_swarm_area
                             && path_id.contains("swarm_area")
                             && first_char_digit(&path_id) > first_char_digit(&self.active_swarm_area)
                         {
-                            self.active_swarm_area = path_id;
+                            self.active_swarm_area = path_id.to_string();
                             for &other in &self.current_swarm.clone() {
                                 if other != id && ctx.rng.random() < self.config.swarm_coordination {
                                     let area = self.active_swarm_area.clone();

--- a/src/engine/animation.rs
+++ b/src/engine/animation.rs
@@ -2,6 +2,9 @@
 //! Scene/Animation stepping that fires events lives on EngineCtx (ctx.rs);
 //! everything here is state plus event-free logic.
 
+use std::collections::VecDeque;
+use std::rc::Rc;
+
 use crate::utils::ansi::{self, ColorCode};
 use crate::utils::easing::Easing;
 use crate::utils::graphics::{Color, ColorPair, Gradient};
@@ -124,7 +127,7 @@ impl CharacterVisual {
 /// upstream object-identity semantics of frame_index_map.
 #[derive(Debug, Clone)]
 pub struct Frame {
-    pub character_visual: CharacterVisual,
+    pub character_visual: Rc<CharacterVisual>,
     pub duration: i64,
     pub ticks_elapsed: i64,
 }
@@ -141,9 +144,9 @@ pub struct Scene {
     /// Stable frame storage; never reordered.
     pub all_frames: Vec<Frame>,
     /// Remaining frame queue (indices into all_frames).
-    pub frames: Vec<usize>,
+    pub frames: VecDeque<usize>,
     /// Played frames (indices into all_frames).
-    pub played_frames: Vec<usize>,
+    pub played_frames: VecDeque<usize>,
     /// Tick index -> frame index (upstream frame_index_map).
     pub frame_index_map: Vec<usize>,
     pub easing_total_steps: i64,
@@ -169,8 +172,8 @@ impl Scene {
             no_color,
             use_xterm_colors,
             all_frames: Vec::new(),
-            frames: Vec::new(),
-            played_frames: Vec::new(),
+            frames: VecDeque::new(),
+            played_frames: VecDeque::new(),
             frame_index_map: Vec::new(),
             easing_total_steps: 0,
             easing_current_step: 0,
@@ -215,8 +218,8 @@ impl Scene {
         }
         let visual = CharacterVisual::new(symbol, params);
         let frame_index = self.all_frames.len();
-        self.all_frames.push(Frame { character_visual: visual, duration, ticks_elapsed: 0 });
-        self.frames.push(frame_index);
+        self.all_frames.push(Frame { character_visual: Rc::new(visual), duration, ticks_elapsed: 0 });
+        self.frames.push_back(frame_index);
         for _ in 0..duration {
             self.frame_index_map.push(frame_index);
             self.easing_total_steps += 1;
@@ -225,8 +228,8 @@ impl Scene {
     }
 
     /// Scene.activate: first frame's visual, error when empty.
-    pub fn activate(&self) -> Result<CharacterVisual, String> {
-        match self.frames.first() {
+    pub fn activate(&self) -> Result<Rc<CharacterVisual>, String> {
+        match self.frames.front() {
             Some(&idx) => Ok(self.all_frames[idx].character_visual.clone()),
             None => Err(format!("Scene {} has no frames.", self.scene_id)),
         }
@@ -234,13 +237,13 @@ impl Scene {
 
     /// Scene.get_next_visual: tick the head frame, retiring it (and looping)
     /// exactly as upstream.
-    pub fn get_next_visual(&mut self) -> CharacterVisual {
+    pub fn get_next_visual(&mut self) -> Rc<CharacterVisual> {
         let head = self.frames[0];
         let next_visual = self.all_frames[head].character_visual.clone();
         self.all_frames[head].ticks_elapsed += 1;
         if self.all_frames[head].ticks_elapsed == self.all_frames[head].duration {
             self.all_frames[head].ticks_elapsed = 0;
-            self.played_frames.push(self.frames.remove(0));
+            self.played_frames.push_back(self.frames.pop_front().unwrap());
             if self.is_looping && self.frames.is_empty() {
                 self.frames.append(&mut self.played_frames);
             }
@@ -342,7 +345,7 @@ impl Scene {
         let remaining: Vec<usize> = self.frames.drain(..).collect();
         for &idx in &remaining {
             self.all_frames[idx].ticks_elapsed = 0;
-            self.played_frames.push(idx);
+            self.played_frames.push_back(idx);
         }
         self.frames.extend(self.played_frames.drain(..));
         self.easing_current_step = 0;
@@ -353,7 +356,7 @@ impl Scene {
 #[derive(Debug, Clone)]
 pub struct Animation {
     pub scenes: OrderedMap<Scene>,
-    pub active_scene: Option<String>,
+    pub active_scene: Option<Rc<str>>,
     pub use_xterm_colors: bool,
     pub no_color: bool,
     pub existing_color_handling: ExistingColorHandling,
@@ -361,7 +364,7 @@ pub struct Animation {
     pub input_bg_color: Option<Color>,
     pub input_bold: bool,
     pub active_scene_current_step: i64,
-    pub current_character_visual: CharacterVisual,
+    pub current_character_visual: Rc<CharacterVisual>,
 }
 
 impl Animation {
@@ -376,7 +379,7 @@ impl Animation {
             input_bg_color: None,
             input_bold: false,
             active_scene_current_step: 0,
-            current_character_visual: CharacterVisual::plain(input_symbol),
+            current_character_visual: Rc::new(CharacterVisual::plain(input_symbol)),
         }
     }
 
@@ -462,7 +465,7 @@ impl Animation {
         }
         let fg_code = self.get_color_code(colors.fg_color.as_ref());
         let bg_code = self.get_color_code(colors.bg_color.as_ref());
-        self.current_character_visual = CharacterVisual::new(
+        self.current_character_visual = Rc::new(CharacterVisual::new(
             symbol,
             VisualParams {
                 bold,
@@ -471,7 +474,7 @@ impl Animation {
                 bg_color_code: bg_code,
                 ..Default::default()
             },
-        );
+        ));
     }
 
     /// Animation.adjust_color_brightness: hand-rolled RGB->HSL->RGB with

--- a/src/engine/ctx.rs
+++ b/src/engine/ctx.rs
@@ -10,6 +10,7 @@
 //! reentrant list mutation behaves like Python list iteration.
 
 use std::collections::BTreeSet;
+use std::rc::Rc;
 use std::time::Instant;
 
 use crate::engine::animation::SyncMetric;
@@ -90,6 +91,7 @@ pub struct EngineCtx {
     /// BaseEffectIterator.active_characters — canonical ascending-id order
     /// (CharId order == character_id order by construction).
     pub active_characters: BTreeSet<CharId>,
+    active_character_scratch: Vec<CharId>,
     pub preexisting_colors_present: bool,
     /// When Some, every event emission appends a trace line (test harness).
     pub event_log: Option<Vec<String>>,
@@ -107,6 +109,7 @@ impl EngineCtx {
             rng,
             clock,
             active_characters: BTreeSet::new(),
+            active_character_scratch: Vec::new(),
             preexisting_colors_present,
             event_log: None,
         })
@@ -253,7 +256,7 @@ impl EngineCtx {
         );
         let layer = {
             let ch = &mut self.terminal.arena[id.0 as usize];
-            ch.motion.active_path = Some(path_id.to_string());
+            ch.motion.active_path = Some(Rc::from(path_id));
             let path = ch.motion.paths.get_mut(path_id).unwrap();
             path.total_distance += distance_to_first_waypoint;
             if let Some(origin) = &path.origin_segment {
@@ -300,52 +303,53 @@ impl EngineCtx {
             };
         }
 
-        {
-            let p = path!();
+        let mut distance_to_travel = {
+            let p = path_mut!();
             if p.max_steps == 0 || p.current_step >= p.max_steps || p.total_distance == 0.0 {
                 return p.segments.last().expect("path has no segments").end.coord;
             }
-        }
-        let (distance_factor, total_distance) = {
-            let p = path_mut!();
             p.current_step += 1;
             let ratio = p.current_step as f64 / p.max_steps as f64;
-            let factor = match &p.ease {
+            let distance_factor = match &p.ease {
                 Some(ease) => ease.ease(ratio),
                 None => ratio,
             };
-            (factor, p.total_distance)
+            let distance = distance_factor * p.total_distance;
+            p.last_distance_reached = distance;
+            distance
         };
-        let mut distance_to_travel = distance_factor * total_distance;
-        path_mut!().last_distance_reached = distance_to_travel;
 
         let mut active_segment_index: Option<usize> = None;
         let mut i = 0usize;
         loop {
-            let (seg_distance, seg_end_key, enter_triggered, exit_triggered) = {
+            let (seg_distance, enter_triggered, exit_triggered) = {
                 let p = path!();
                 if i >= p.segments.len() {
                     break;
                 }
                 let seg = &p.segments[i];
-                (seg.distance, seg.end.key(), seg.enter_event_triggered, seg.exit_event_triggered)
+                (seg.distance, seg.enter_event_triggered, seg.exit_event_triggered)
             };
             if distance_to_travel <= seg_distance {
                 active_segment_index = Some(i);
                 if !enter_triggered {
+                    let seg_end_key = path!().segments[i].end.key();
                     path_mut!().segments[i].enter_event_triggered = true;
                     self.handle_event(hooks, id, Event::SegmentEntered, &CallerKey::Waypoint(seg_end_key));
                 }
                 break;
             }
             distance_to_travel -= seg_distance;
-            if !enter_triggered {
-                path_mut!().segments[i].enter_event_triggered = true;
-                self.handle_event(hooks, id, Event::SegmentEntered, &CallerKey::Waypoint(seg_end_key.clone()));
-            }
-            if !exit_triggered {
-                path_mut!().segments[i].exit_event_triggered = true;
-                self.handle_event(hooks, id, Event::SegmentExited, &CallerKey::Waypoint(seg_end_key));
+            if !enter_triggered || !exit_triggered {
+                let seg_end_key = path!().segments[i].end.key();
+                if !enter_triggered {
+                    path_mut!().segments[i].enter_event_triggered = true;
+                    self.handle_event(hooks, id, Event::SegmentEntered, &CallerKey::Waypoint(seg_end_key.clone()));
+                }
+                if !exit_triggered {
+                    path_mut!().segments[i].exit_event_triggered = true;
+                    self.handle_event(hooks, id, Event::SegmentExited, &CallerKey::Waypoint(seg_end_key));
+                }
             }
             i += 1;
         }
@@ -361,21 +365,19 @@ impl EngineCtx {
             }
         };
 
-        let (seg_distance, seg_start_coord, seg_end_coord, seg_bezier, has_ease) = {
-            let p = path!();
-            let seg = &p.segments[active_segment_index];
-            (seg.distance, seg.start.coord, seg.end.coord, seg.end.bezier_control.clone(), p.ease.is_some())
-        };
+        let p = path!();
+        let seg = &p.segments[active_segment_index];
+        let seg_distance = seg.distance;
         let t = if seg_distance == 0.0 {
             0.0
-        } else if has_ease {
+        } else if p.ease.is_some() {
             distance_to_travel / seg_distance // unclamped: eased overshoot goes past the waypoint
         } else {
             (distance_to_travel / seg_distance).min(1.0)
         };
-        match seg_bezier {
-            Some(control) => geometry::find_coord_on_bezier_curve(seg_start_coord, &control, seg_end_coord, t),
-            None => geometry::find_coord_on_line(seg_start_coord, seg_end_coord, t),
+        match &seg.end.bezier_control {
+            Some(control) => geometry::find_coord_on_bezier_curve(seg.start.coord, control, seg.end.coord, t),
+            None => geometry::find_coord_on_line(seg.start.coord, seg.end.coord, t),
         }
     }
 
@@ -414,7 +416,7 @@ impl EngineCtx {
         };
         if current_step == max_steps {
             if hold_time != 0 && hold_time_remaining == hold_time {
-                self.handle_event(hooks, id, Event::PathHolding, &CallerKey::Path(active_path_id.clone()));
+                self.handle_event(hooks, id, Event::PathHolding, &CallerKey::Path(active_path_id.to_string()));
                 self.terminal.arena[id.0 as usize]
                     .motion
                     .paths
@@ -441,7 +443,7 @@ impl EngineCtx {
                     motion.completed_path = Some(active_path_id.clone());
                     motion.deactivate_path(Some(&active_path_id));
                 }
-                self.handle_event(hooks, id, Event::PathComplete, &CallerKey::Path(active_path_id));
+                self.handle_event(hooks, id, Event::PathComplete, &CallerKey::Path(active_path_id.to_string()));
             }
         }
     }
@@ -485,7 +487,7 @@ impl EngineCtx {
                 .expect("activate_scene: scene not found")
                 .activate()
                 .expect("activate_scene: empty scene");
-            ch.animation.active_scene = Some(scene_id.to_string());
+            ch.animation.active_scene = Some(Rc::from(scene_id));
             ch.animation.active_scene_current_step = 0;
             ch.animation.current_character_visual = visual;
         }
@@ -551,7 +553,7 @@ impl EngineCtx {
         match active_path_state {
             None => {
                 // no active path: jump to final frame and force-complete
-                let last = *scene.frames.last().unwrap();
+                let last = *scene.frames.back().unwrap();
                 ch.animation.current_character_visual = scene.all_frames[last].character_visual.clone();
                 let drained: Vec<usize> = scene.frames.drain(..).collect();
                 scene.played_frames.extend(drained);
@@ -636,19 +638,17 @@ impl EngineCtx {
     /// BaseEffectIterator.update: tick a snapshot of active characters in
     /// canonical ascending-id order, then prune the not-is_active ones.
     pub fn update(&mut self, hooks: &mut dyn EffectHooks) {
-        let snapshot: Vec<CharId> = self.active_characters.iter().copied().collect();
-        for id in snapshot {
+        let mut snapshot = std::mem::take(&mut self.active_character_scratch);
+        snapshot.clear();
+        snapshot.extend(self.active_characters.iter().copied());
+        for &id in &snapshot {
             self.tick(hooks, id);
         }
-        let inactive: Vec<CharId> = self
-            .active_characters
-            .iter()
-            .copied()
-            .filter(|&id| !self.terminal.arena[id.0 as usize].is_active())
-            .collect();
-        for id in inactive {
-            self.active_characters.remove(&id);
-        }
+        snapshot.clear();
+        self.active_character_scratch = snapshot;
+
+        let arena = &self.terminal.arena;
+        self.active_characters.retain(|id| arena[id.0 as usize].is_active());
     }
 
     /// BaseEffectIterator.frame: enforce framerate (real clock only), then the

--- a/src/engine/effect.rs
+++ b/src/engine/effect.rs
@@ -27,6 +27,7 @@ pub fn run_effect(effect: &mut dyn Effect, ctx: &mut EngineCtx) -> Result<(), En
                 break;
             }
             ctx.terminal.print_frame(&mut out, &frame).map_err(io_err)?;
+            ctx.terminal.recycle_output_string(frame);
         }
         Ok(())
     })();
@@ -47,9 +48,10 @@ pub fn dump_effect(
     let mut count: u64 = 0;
     while let Some(frame) = effect.next_frame(ctx) {
         let data = frame.as_bytes();
-        out.write_all(format!("{}\n", data.len()).as_bytes()).map_err(io_err)?;
+        writeln!(out, "{}", data.len()).map_err(io_err)?;
         out.write_all(data).map_err(io_err)?;
         out.write_all(b"\n").map_err(io_err)?;
+        ctx.terminal.recycle_output_string(frame);
         count += 1;
         if max_frames.is_some_and(|m| count >= m) {
             break;

--- a/src/engine/motion.rs
+++ b/src/engine/motion.rs
@@ -2,6 +2,8 @@
 //! logic that fires events (Path.step, Motion.move, activate_path) lives on
 //! EngineCtx (ctx.rs) so actions run inline at upstream emission points.
 
+use std::rc::Rc;
+
 use crate::engine::events::WaypointKey;
 use crate::utils::easing::Easing;
 use crate::utils::geometry::{self, Coord};
@@ -152,8 +154,8 @@ pub struct Motion {
     pub paths: OrderedMap<Path>,
     pub current_coord: Coord,
     pub previous_coord: Coord,
-    pub active_path: Option<String>,
-    pub completed_path: Option<String>,
+    pub active_path: Option<Rc<str>>,
+    pub completed_path: Option<Rc<str>>,
 }
 
 impl Motion {

--- a/src/engine/terminal.rs
+++ b/src/engine/terminal.rs
@@ -2,7 +2,7 @@
 //! Ported from engine/terminal.py. Unlike upstream (which builds two Terminals
 //! per run), this single Terminal owns both the simulation and the tty side.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::io::Write;
 use std::time::Instant;
 
@@ -15,6 +15,9 @@ use crate::utils::ansi;
 use crate::utils::geometry::Coord;
 use crate::utils::graphics::Color;
 use crate::utils::rng::Rng;
+
+const EMPTY_RENDER_CELL: u32 = u32::MAX;
+const NOT_VISIBLE: usize = usize::MAX;
 
 #[derive(Debug, Clone)]
 pub struct TerminalConfig {
@@ -126,8 +129,12 @@ pub struct Terminal {
     pub character_by_input_coord: HashMap<Coord, CharId>,
     pub inner_fill_characters: Vec<CharId>,
     pub outer_fill_characters: Vec<CharId>,
-    visible_characters: HashSet<CharId>,
+    visible_characters: Vec<CharId>,
+    visible_positions: Vec<usize>,
+    render_cells: Vec<u32>,
     pub terminal_state: Vec<String>,
+    output_buffer: String,
+    move_cursor_to_top: String,
     frame_rate: i64,
     last_time_printed: Instant,
 }
@@ -179,6 +186,13 @@ impl Terminal {
         }
 
         let frame_rate = config.frame_rate;
+        let arena_len = arena.len();
+        let move_cursor_to_top = format!(
+            "{}{}{}",
+            ansi::DEC_RESTORE_CURSOR,
+            ansi::DEC_SAVE_CURSOR,
+            ansi::move_cursor_up(visible_top.max(0) as usize)
+        );
         let mut terminal = Terminal {
             config,
             canvas,
@@ -198,8 +212,12 @@ impl Terminal {
             character_by_input_coord,
             inner_fill_characters: Vec::new(),
             outer_fill_characters: Vec::new(),
-            visible_characters: HashSet::new(),
+            visible_characters: Vec::new(),
+            visible_positions: vec![NOT_VISIBLE; arena_len],
+            render_cells: Vec::new(),
             terminal_state: Vec::new(),
+            output_buffer: String::new(),
+            move_cursor_to_top,
             frame_rate,
             last_time_printed: Instant::now(),
         };
@@ -275,11 +293,22 @@ impl Terminal {
     }
 
     pub fn set_character_visibility(&mut self, id: CharId, is_visible: bool) {
-        self.arena[id.0 as usize].is_visible = is_visible;
+        let arena_index = id.0 as usize;
+        if self.arena[arena_index].is_visible == is_visible {
+            return;
+        }
+        self.arena[arena_index].is_visible = is_visible;
+        self.visible_positions.resize(self.arena.len(), NOT_VISIBLE);
         if is_visible {
-            self.visible_characters.insert(id);
+            self.visible_positions[arena_index] = self.visible_characters.len();
+            self.visible_characters.push(id);
         } else {
-            self.visible_characters.remove(&id);
+            let position = std::mem::replace(&mut self.visible_positions[arena_index], NOT_VISIBLE);
+            self.visible_characters.swap_remove(position);
+            if position < self.visible_characters.len() {
+                let moved = self.visible_characters[position];
+                self.visible_positions[moved.0 as usize] = position;
+            }
         }
     }
 
@@ -457,13 +486,15 @@ impl Terminal {
     pub fn update_terminal_state(&mut self) {
         let width = self.visible_right.max(0) as usize;
         let height = self.visible_top.max(0) as usize;
-        let mut rows: Vec<Vec<&str>> = vec![vec![" "; width]; height];
-        let mut visible: Vec<CharId> = self.visible_characters.iter().copied().collect();
-        visible.sort_by_key(|&id| {
-            let ch = &self.arena[id.0 as usize];
-            (ch.layer, ch.character_id)
-        });
-        for id in visible {
+        let cell_count = width.checked_mul(height).expect("terminal canvas is too large");
+        self.render_cells.resize(cell_count, EMPTY_RENDER_CELL);
+        self.render_cells.fill(EMPTY_RENDER_CELL);
+
+        // The old implementation sorted every visible character by painter
+        // order and overwrote cells in that order.  A cell only needs the
+        // maximum key, so select that winner directly and avoid the per-frame
+        // allocation and O(n log n) sort.
+        for &id in &self.visible_characters {
             let ch = &self.arena[id.0 as usize];
             let row = ch.motion.current_coord.row + self.canvas_row_offset;
             let column = ch.motion.current_coord.column + self.canvas_column_offset;
@@ -472,17 +503,46 @@ impl Terminal {
                 && self.visible_left <= column
                 && column <= self.visible_right
             {
-                rows[(row - 1) as usize][(column - 1) as usize] =
-                    &ch.animation.current_character_visual.formatted_symbol;
+                let cell = &mut self.render_cells[(row - 1) as usize * width + (column - 1) as usize];
+                if *cell == EMPTY_RENDER_CELL {
+                    *cell = id.0;
+                } else {
+                    let painted = &self.arena[*cell as usize];
+                    if (ch.layer, ch.character_id) > (painted.layer, painted.character_id) {
+                        *cell = id.0;
+                    }
+                }
             }
         }
-        self.terminal_state = rows.into_iter().map(|row| row.concat()).collect();
+
+        self.terminal_state.resize_with(height, String::new);
+        self.terminal_state.truncate(height);
+        let arena = &self.arena;
+        for (row_index, row) in self.terminal_state.iter_mut().enumerate() {
+            row.clear();
+            if row.capacity() < width {
+                row.reserve(width);
+            }
+            for &cell in &self.render_cells[row_index * width..(row_index + 1) * width] {
+                if cell == EMPTY_RENDER_CELL {
+                    row.push(' ');
+                } else {
+                    row.push_str(&arena[cell as usize].animation.current_character_visual.formatted_symbol);
+                }
+            }
+        }
     }
 
     /// get_formatted_output_string: refresh + join top row first.
     pub fn get_formatted_output_string(&mut self) -> String {
         self.update_terminal_state();
-        let mut out = String::new();
+        let content_len: usize = self.terminal_state.iter().map(String::len).sum();
+        let required_capacity = content_len + self.terminal_state.len().saturating_sub(1);
+        let mut out = std::mem::take(&mut self.output_buffer);
+        out.clear();
+        if out.capacity() < required_capacity {
+            out.reserve(required_capacity);
+        }
         for (i, row) in self.terminal_state.iter().rev().enumerate() {
             if i > 0 {
                 out.push('\n');
@@ -490,6 +550,13 @@ impl Terminal {
             out.push_str(row);
         }
         out
+    }
+
+    pub(crate) fn recycle_output_string(&mut self, mut output: String) {
+        output.clear();
+        if output.capacity() > self.output_buffer.capacity() {
+            self.output_buffer = output;
+        }
     }
 
     // --- tty side (upstream's second Terminal instance) ---
@@ -524,10 +591,7 @@ impl Terminal {
     }
 
     fn write_move_cursor_to_top(&self, out: &mut impl Write) -> std::io::Result<()> {
-        out.write_all(ansi::DEC_RESTORE_CURSOR.as_bytes())?;
-        out.write_all(ansi::DEC_SAVE_CURSOR.as_bytes())?;
-        out.write_all(ansi::move_cursor_up(self.visible_top.max(0) as usize).as_bytes())?;
-        Ok(())
+        out.write_all(self.move_cursor_to_top.as_bytes())
     }
 
     /// Terminal.enforce_framerate: sleep off the remainder; timestamp taken

--- a/src/utils/ordered_map.rs
+++ b/src/utils/ordered_map.rs
@@ -1,16 +1,24 @@
 //! Insertion-ordered string-keyed map with Python-dict iteration semantics.
 //! Used everywhere upstream iterates dict values (plan.md §4.3): motion.paths,
-//! animation.scenes, effect-level dicts. Populations are small; lookups are
-//! linear scans, which profile fine at terminal scale.
+//! animation.scenes, effect-level dicts. Small maps use a compact linear scan;
+//! larger maps add a lookup index while retaining the canonical entry order.
 
-#[derive(Debug, Clone, Default)]
+use std::cell::Cell;
+use std::collections::HashMap;
+
+const INDEX_THRESHOLD: usize = 8;
+const NO_CACHED_LOOKUP: usize = usize::MAX;
+
+#[derive(Debug, Clone)]
 pub struct OrderedMap<V> {
     entries: Vec<(String, V)>,
+    index: Option<Box<HashMap<String, usize>>>,
+    last_lookup: Cell<usize>,
 }
 
 impl<V> OrderedMap<V> {
     pub fn new() -> Self {
-        OrderedMap { entries: Vec::new() }
+        OrderedMap { entries: Vec::new(), index: None, last_lookup: Cell::new(NO_CACHED_LOOKUP) }
     }
 
     pub fn len(&self) -> usize {
@@ -22,24 +30,39 @@ impl<V> OrderedMap<V> {
     }
 
     pub fn contains_key(&self, key: &str) -> bool {
-        self.entries.iter().any(|(k, _)| k == key)
+        self.position(key).is_some()
     }
 
     /// Python dict semantics: overwriting an existing key keeps its position.
     pub fn insert(&mut self, key: String, value: V) {
-        if let Some(entry) = self.entries.iter_mut().find(|(k, _)| *k == key) {
-            entry.1 = value;
-        } else {
-            self.entries.push((key, value));
+        if let Some(position) = self.position(&key) {
+            self.entries[position].1 = value;
+            return;
+        }
+        let position = self.entries.len();
+        if let Some(index) = &mut self.index {
+            index.insert(key.clone(), position);
+        }
+        self.entries.push((key, value));
+        self.last_lookup.set(position);
+        if self.entries.len() == INDEX_THRESHOLD {
+            let index = self
+                .entries
+                .iter()
+                .enumerate()
+                .map(|(position, (key, _))| (key.clone(), position))
+                .collect();
+            self.index = Some(Box::new(index));
         }
     }
 
     pub fn get(&self, key: &str) -> Option<&V> {
-        self.entries.iter().find(|(k, _)| k == key).map(|(_, v)| v)
+        self.position(key).map(|position| &self.entries[position].1)
     }
 
     pub fn get_mut(&mut self, key: &str) -> Option<&mut V> {
-        self.entries.iter_mut().find(|(k, _)| k == key).map(|(_, v)| v)
+        let position = self.position(key)?;
+        Some(&mut self.entries[position].1)
     }
 
     pub fn keys(&self) -> impl Iterator<Item = &String> {
@@ -61,11 +84,67 @@ impl<V> OrderedMap<V> {
     /// Python dict.pop(key, None): removes the entry, preserving the order of
     /// the remaining entries.
     pub fn remove(&mut self, key: &str) -> Option<V> {
-        let pos = self.entries.iter().position(|(k, _)| k == key)?;
+        let pos = self.position(key)?;
+        if let Some(index) = &mut self.index {
+            index.remove(key);
+            for indexed_position in index.values_mut() {
+                if *indexed_position > pos {
+                    *indexed_position -= 1;
+                }
+            }
+        }
+        self.last_lookup.set(NO_CACHED_LOOKUP);
         Some(self.entries.remove(pos).1)
     }
 
     pub fn clear(&mut self) {
         self.entries.clear();
+        self.last_lookup.set(NO_CACHED_LOOKUP);
+        if let Some(index) = &mut self.index {
+            index.clear();
+        }
+    }
+
+    fn position(&self, key: &str) -> Option<usize> {
+        let cached = self.last_lookup.get();
+        if cached < self.entries.len() && self.entries[cached].0 == key {
+            return Some(cached);
+        }
+        let position = match &self.index {
+            Some(index) => index.get(key).copied(),
+            None => self.entries.iter().position(|(entry_key, _)| entry_key == key),
+        };
+        self.last_lookup.set(position.unwrap_or(NO_CACHED_LOOKUP));
+        position
+    }
+}
+
+impl<V> Default for OrderedMap<V> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn indexed_maps_preserve_order_and_lookup_after_mutation() {
+        let mut map = OrderedMap::new();
+        for value in 0..12 {
+            map.insert(value.to_string(), value);
+        }
+        map.insert("3".to_string(), 30);
+        assert_eq!(map.get("3"), Some(&30));
+        assert_eq!(map.keys().map(String::as_str).collect::<Vec<_>>()[..5], ["0", "1", "2", "3", "4"]);
+
+        assert_eq!(map.remove("4"), Some(4));
+        assert_eq!(map.get("5"), Some(&5));
+        assert!(!map.contains_key("4"));
+
+        map.clear();
+        map.insert("fresh".to_string(), 99);
+        assert_eq!(map.get("fresh"), Some(&99));
     }
 }

--- a/tests/engine_traces.rs
+++ b/tests/engine_traces.rs
@@ -48,8 +48,8 @@ fn snapshot(ctx: &mut EngineCtx, log: &mut Vec<String>, tick: i64, ids: &[CharId
     log.append(ctx.event_log.as_mut().unwrap());
     for &id in ids {
         let ch = &ctx.terminal.arena[id.0 as usize];
-        let ap = ch.motion.active_path.clone().unwrap_or_else(|| "-".to_string());
-        let sc = ch.animation.active_scene.clone().unwrap_or_else(|| "-".to_string());
+        let ap = ch.motion.active_path.as_deref().unwrap_or("-");
+        let sc = ch.animation.active_scene.as_deref().unwrap_or("-");
         let active = if ch.is_active() { "True" } else { "False" };
         log.push(format!(
             "tick={tick} char={} coord={},{} layer={} path={ap} scene={sc} vis={} active={active}",


### PR DESCRIPTION
## Summary

- replace the per-frame visible-character sort and temporary grid allocations with reusable dense painter buffers
- share immutable animation visuals, use constant-time frame queues, and recycle frame output storage
- cache active scene/path identifiers and active-character scratch space
- cache repeated ordered-map lookups and add indexed lookup for larger path maps
- avoid redundant path lookups, waypoint cloning, and Bezier-control cloning while stepping motion

## Performance

Compared the release build on this branch with an untouched `main` release build on the same machine. The benchmark covered all 35 non-clock-bound effects using a 20x64 input, seed 1, frame pacing disabled, and the median of seven alternating runs per binary/effect.

| Metric | Before | After | Improvement |
|---|---:|---:|---:|
| Whole-suite throughput | 11,623 FPS | 18,878 FPS | **+62.4%** |
| Median per-effect FPS | - | - | **+52.7%** |
| Geometric-mean FPS | - | - | **+60.8%** |
| `rings` | 3,950 FPS | 9,945 FPS | **+151.8%** |

`matrix` and `thunderstorm` are excluded because they intentionally run for fixed wall-clock durations.

### Combined speedup over upstream TTE

A three-way end-to-end benchmark compared the pinned Python TTE v0.15.0 (`7a91dd9`), an untouched `main` build, and this branch. It used the same 35 effects and 20x64 input, seed 1 on both implementations, normal user-facing CLI paths, frame pacing disabled, and the median of three runs in rotating order.

| Comparison | Geometric mean | Median effect | Whole suite |
|---|---:|---:|---:|
| Python TTE → `main` | 9.381x | 9.328x | 8.397x |
| `main` → this PR | 1.560x | 1.518x | 1.599x |
| Python TTE → this PR | **14.640x** | **14.291x** | **13.423x** |

The combined geometric-mean speedup is both directly measured and multiplicative: **9.381x × 1.560x = 14.640x** over upstream TTE (**+1,364% throughput**). Aggregate suite runtime fell from 18.421s to 1.372s, a 13.423x speedup and 92.6% reduction.

## Verification

- `cargo test --release`
- 354/354 baseline frame streams byte-identical
- 41/41 baseline terminal byte streams byte-identical
- 19/19 CLI contract cases passed
