### PR TITLE
Maximize frame throughput across all effects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ terminal_size = "0.4"
 lto = true
 strip = true
 codegen-units = 1
+panic = "abort"

--- a/src/effects/beams.rs
+++ b/src/effects/beams.rs
@@ -226,7 +226,8 @@ impl Effect for Beams {
         for column in ctx.terminal.get_characters_grouped(all_chars_filter, CharacterGroup::ColumnLeftToRight) {
             groups.push(self.make_group(ctx, column, Direction::Column));
         }
-        for group in &groups {
+        // Rows and columns contain the same characters; initialize each character's scenes only once.
+        for group in groups.iter().filter(|group| group.direction == Direction::Row) {
             for &id in &group.characters {
                 let (input_symbol, uses_pre) = {
                     let ch = &ctx.terminal.arena[id.0 as usize];

--- a/src/effects/blackhole.rs
+++ b/src/effects/blackhole.rs
@@ -588,7 +588,7 @@ impl Effect for Blackhole {
                         self.awaiting_consumption_chars.clear();
                     } else {
                         let blackhole_set: HashSet<CharId> = self.blackhole_chars.iter().copied().collect();
-                        if ctx.active_characters.iter().all(|id| blackhole_set.contains(id)) {
+                        if ctx.active_characters.iter().all(|id| blackhole_set.contains(&id)) {
                             self.phase = Phase::Collapsing;
                         }
                     }

--- a/src/effects/decrypt.rs
+++ b/src/effects/decrypt.rs
@@ -348,7 +348,7 @@ impl Effect for Decrypt {
             // canonical ascending-id order.
             ctx.active_characters.clear();
             ctx.active_characters.extend(self.decrypting_pending_chars.iter().copied());
-            let active: Vec<CharId> = ctx.active_characters.iter().copied().collect();
+            let active: Vec<CharId> = ctx.active_characters.iter().collect();
             for id in active {
                 ctx.activate_scene(self, id, "fast_decrypt");
             }

--- a/src/effects/highlight.rs
+++ b/src/effects/highlight.rs
@@ -159,15 +159,15 @@ impl Effect for Highlight {
     fn next_frame(&mut self, ctx: &mut EngineCtx) -> Option<String> {
         let easer_complete = self.easer.as_ref().unwrap().is_complete();
         if !ctx.active_characters.is_empty() || !easer_complete {
-            let easer = self.easer.as_mut().unwrap();
-            easer.step();
-            let added = easer.added.clone();
-            for group in added {
-                for id in group {
+            let mut easer = self.easer.take().unwrap();
+            let step = easer.step();
+            for group in step.added {
+                for &id in group {
                     ctx.activate_scene(self, id, "highlight");
                     ctx.active_characters.insert(id);
                 }
             }
+            self.easer = Some(easer);
             ctx.update(self);
             return Some(ctx.frame());
         }

--- a/src/effects/matrix.rs
+++ b/src/effects/matrix.rs
@@ -286,24 +286,57 @@ impl RainColumn {
         }
 
         // randomly change the symbol and/or color of the characters
-        let visible_snapshot = self.visible_characters.clone();
-        for character in visible_snapshot {
+        for &character in &self.visible_characters {
+            // Draw both chances (and any resulting choices) in upstream order,
+            // but leave the cached visual alone when neither value changes.
             let next_symbol = if ctx.rng.random() < config.symbol_swap_chance {
-                ctx.rng.choice(&config.rain_symbols).clone()
+                Some(ctx.rng.choice(&config.rain_symbols).as_str())
             } else {
-                ctx.terminal.arena[character.0 as usize].animation.current_character_visual.symbol.clone()
+                None
             };
-            let next_color: Option<Color> = if ctx.rng.random() < config.color_swap_chance {
-                Some(ctx.rng.choice(rain_colors).clone())
+            let next_color = if ctx.rng.random() < config.color_swap_chance {
+                Some(ctx.rng.choice(rain_colors))
             } else {
-                ctx.terminal.arena[character.0 as usize]
-                    .animation
-                    .current_character_visual
-                    .colors
-                    .as_ref()
-                    .and_then(|colors| colors.fg_color.clone())
+                None
             };
-            set_appearance(ctx, character, &next_symbol, ColorPair::new(next_color, None));
+            if next_symbol.is_none() && next_color.is_none() {
+                continue;
+            }
+
+            let values_unchanged = {
+                let visual = &ctx.terminal.arena[character.0 as usize].animation.current_character_visual;
+                next_symbol.is_none_or(|symbol| symbol == visual.symbol)
+                    && next_color.is_none_or(|color| {
+                        visual.colors.as_ref().and_then(|colors| colors.fg_color.as_ref()) == Some(color)
+                    })
+            };
+            if values_unchanged {
+                continue;
+            }
+
+            match (next_symbol, next_color) {
+                (Some(symbol), Some(color)) => {
+                    set_appearance(ctx, character, symbol, ColorPair::new(Some(color.clone()), None));
+                }
+                (Some(symbol), None) => {
+                    let color = ctx.terminal.arena[character.0 as usize]
+                        .animation
+                        .current_character_visual
+                        .colors
+                        .as_ref()
+                        .and_then(|colors| colors.fg_color.clone());
+                    set_appearance(ctx, character, symbol, ColorPair::new(color, None));
+                }
+                (None, Some(color)) => {
+                    let symbol = ctx.terminal.arena[character.0 as usize]
+                        .animation
+                        .current_character_visual
+                        .symbol
+                        .clone();
+                    set_appearance(ctx, character, &symbol, ColorPair::new(Some(color.clone()), None));
+                }
+                (None, None) => unreachable!("no-change case returned above"),
+            }
         }
     }
 }

--- a/src/effects/middleout.rs
+++ b/src/effects/middleout.rs
@@ -249,7 +249,7 @@ impl Effect for Middleout {
             };
             ctx.active_characters = characters.into_iter().collect();
             // upstream iterates the set here; canonical ascending character_id
-            let ordered: Vec<CharId> = ctx.active_characters.iter().copied().collect();
+            let ordered: Vec<CharId> = ctx.active_characters.iter().collect();
             for id in ordered {
                 ctx.activate_path(self, id, "full");
                 ctx.activate_scene(self, id, "full");

--- a/src/effects/overflow.rs
+++ b/src/effects/overflow.rs
@@ -1,6 +1,6 @@
 //! overflow, ported from effects/effect_overflow.py.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 
 use clap::Args;
 
@@ -92,7 +92,7 @@ impl Row {
 
 pub struct Overflow {
     config: OverflowConfig,
-    pending_rows: Vec<Row>,
+    pending_rows: VecDeque<Row>,
     active_rows: Vec<Row>,
     character_final_color_map: HashMap<CharId, Color>,
     delay: i64,
@@ -103,7 +103,7 @@ impl Overflow {
     pub fn new(config: OverflowConfig) -> Self {
         Overflow {
             config,
-            pending_rows: Vec::new(),
+            pending_rows: VecDeque::new(),
             active_rows: Vec::new(),
             character_final_color_map: HashMap::new(),
             delay: 0,
@@ -180,7 +180,7 @@ impl Effect for Overflow {
                         copy.animation.input_bg_color = input_bg;
                         copied_characters.push(copy_id);
                     }
-                    self.pending_rows.push(Row { characters: copied_characters, final_: false });
+                    self.pending_rows.push_back(Row { characters: copied_characters, final_: false });
                 }
             }
         }
@@ -220,7 +220,7 @@ impl Effect for Overflow {
                     );
                 }
             }
-            self.pending_rows.push(Row { characters: row, final_: true });
+            self.pending_rows.push_back(Row { characters: row, final_: true });
         }
         self.delay = 0;
         let steps = std::cmp::max(
@@ -240,7 +240,7 @@ impl Effect for Overflow {
     fn next_frame(&mut self, ctx: &mut EngineCtx) -> Option<String> {
         if !self.pending_rows.is_empty() {
             if self.delay == 0 {
-                let spectrum = self.overflow_gradient.as_ref().unwrap().spectrum.clone();
+                let spectrum = &self.overflow_gradient.as_ref().unwrap().spectrum;
                 for _ in 0..ctx.rng.randint(1, self.config.overflow_speed) {
                     if !self.pending_rows.is_empty() {
                         for row in &self.active_rows {
@@ -252,7 +252,7 @@ impl Effect for Overflow {
                                 row.set_color(ctx, Some(spectrum[index].clone()), None);
                             }
                         }
-                        let next_row = self.pending_rows.remove(0);
+                        let next_row = self.pending_rows.pop_front().unwrap();
                         next_row.setup(ctx);
                         next_row.move_up(ctx);
                         if !next_row.final_ {

--- a/src/effects/slice.rs
+++ b/src/effects/slice.rs
@@ -250,7 +250,7 @@ impl Effect for Slice {
                 }
             }
         }
-        let active: Vec<CharId> = ctx.active_characters.iter().copied().collect();
+        let active: Vec<CharId> = ctx.active_characters.iter().collect();
         for id in active {
             ctx.terminal.set_character_visibility(id, true);
         }

--- a/src/effects/sweep.rs
+++ b/src/effects/sweep.rs
@@ -226,29 +226,29 @@ impl Effect for Sweep {
 
     fn next_frame(&mut self, ctx: &mut EngineCtx) -> Option<String> {
         if !ctx.active_characters.is_empty() || !self.complete {
-            self.easer.as_mut().unwrap().step();
-            let added = self.easer.as_ref().unwrap().added.clone();
-            for group in added {
-                for &id in &group {
+            let mut easer = self.easer.take().unwrap();
+            let step = easer.step();
+            for group in step.added {
+                for &id in group {
                     if self.first_phase {
                         ctx.terminal.set_character_visibility(id, true);
                     }
                     let scene_id = if self.first_phase { "initial_sweep" } else { "second_sweep" };
                     ctx.activate_scene(self, id, scene_id);
                 }
-                for id in group {
+                for &id in group {
                     ctx.active_characters.insert(id);
                 }
             }
-            let easer_complete = self.easer.as_ref().unwrap().is_complete();
+            let easer_complete = easer.is_complete();
             if easer_complete && self.first_phase {
-                let easer = self.easer.as_mut().unwrap();
                 easer.sequence = std::mem::take(&mut self.groups_second_sweep);
                 easer.reset();
                 self.first_phase = false;
             } else if easer_complete && !self.first_phase {
                 self.complete = true;
             }
+            self.easer = Some(easer);
             ctx.update(self);
             return Some(ctx.frame());
         }

--- a/src/effects/unstable.rs
+++ b/src/effects/unstable.rs
@@ -415,14 +415,13 @@ impl Effect for Unstable {
             if !ctx.active_characters.is_empty() {
                 // Upstream iterates the active_characters set (effect_unstable.py:332);
                 // canonical order is ascending character_id (shim patched to match).
-                let snapshot: Vec<CharId> = ctx.active_characters.iter().copied().collect();
+                let snapshot: Vec<CharId> = ctx.active_characters.iter().collect();
                 for id in snapshot {
                     ctx.tick(self, id);
                 }
                 let retained: Vec<CharId> = ctx
                     .active_characters
                     .iter()
-                    .copied()
                     .filter(|&id| {
                         let ch = &ctx.terminal.arena[id.0 as usize];
                         let explosion_target = ch.motion.paths.get("explosion").unwrap().waypoints[0].coord;
@@ -453,14 +452,13 @@ impl Effect for Unstable {
         if self.phase == Phase::Reassembly && !ctx.active_characters.is_empty() {
             // Upstream iterates the active_characters set (effect_unstable.py:354);
             // canonical order is ascending character_id (shim patched to match).
-            let snapshot: Vec<CharId> = ctx.active_characters.iter().copied().collect();
+            let snapshot: Vec<CharId> = ctx.active_characters.iter().collect();
             for id in snapshot {
                 ctx.tick(self, id);
             }
             let retained: Vec<CharId> = ctx
                 .active_characters
                 .iter()
-                .copied()
                 .filter(|&id| {
                     let ch = &ctx.terminal.arena[id.0 as usize];
                     let reassembly_target = ch.motion.paths.get("reassembly").unwrap().waypoints[0].coord;

--- a/src/effects/wipe.rs
+++ b/src/effects/wipe.rs
@@ -153,19 +153,17 @@ impl Effect for Wipe {
         let easer_complete = self.easer.as_ref().unwrap().is_complete();
         if !ctx.active_characters.is_empty() || !easer_complete {
             if self.wipe_delay == 0 {
-                let easer = self.easer.as_mut().unwrap();
-                easer.step();
-                let added = easer.added.clone();
-                let removed = easer.removed.clone();
-                for group in added {
-                    for id in group {
+                let mut easer = self.easer.take().unwrap();
+                let step = easer.step();
+                for group in step.added {
+                    for &id in group {
                         ctx.activate_scene(self, id, "wipe");
                         ctx.terminal.set_character_visibility(id, true);
                         ctx.active_characters.insert(id);
                     }
                 }
-                for group in removed {
-                    for id in group {
+                for group in step.removed {
+                    for &id in group {
                         ctx.deactivate_scene(id, None);
                         ctx.terminal.arena[id.0 as usize]
                             .animation
@@ -176,6 +174,7 @@ impl Effect for Wipe {
                         ctx.terminal.set_character_visibility(id, false);
                     }
                 }
+                self.easer = Some(easer);
                 self.wipe_delay = self.config.wipe_delay;
             } else {
                 self.wipe_delay -= 1;

--- a/src/engine/active_characters.rs
+++ b/src/engine/active_characters.rs
@@ -1,0 +1,363 @@
+//! Dense ordered set for active arena characters.
+//!
+//! `CharId` is a dense arena index, so a packed bitmap avoids the allocation
+//! and pointer chasing of a tree while its set bits naturally iterate in
+//! ascending id order.
+
+use std::iter::FromIterator;
+
+use crate::engine::character::CharId;
+
+const WORD_BITS: usize = u64::BITS as usize;
+const PROMOTE_LEN: usize = 128;
+const DEMOTE_LEN: usize = 64;
+
+#[derive(Clone, Default)]
+pub struct ActiveCharacters {
+    sparse: Vec<CharId>,
+    words: Vec<u64>,
+    len: usize,
+    dense: bool,
+}
+
+impl ActiveCharacters {
+    #[inline]
+    pub const fn new() -> Self {
+        Self {
+            sparse: Vec::new(),
+            words: Vec::new(),
+            len: 0,
+            dense: false,
+        }
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    #[inline]
+    pub fn clear(&mut self) {
+        self.sparse.clear();
+        self.words.clear();
+        self.len = 0;
+        self.dense = false;
+    }
+
+    #[inline]
+    pub fn contains(&self, id: &CharId) -> bool {
+        if !self.dense {
+            return self.sparse.binary_search(id).is_ok();
+        }
+        let index = id.0 as usize;
+        self.words
+            .get(index / WORD_BITS)
+            .is_some_and(|word| word & (1 << (index % WORD_BITS)) != 0)
+    }
+
+    #[inline]
+    pub fn insert(&mut self, id: CharId) -> bool {
+        if !self.dense {
+            let Err(index) = self.sparse.binary_search(&id) else {
+                return false;
+            };
+            self.sparse.insert(index, id);
+            self.len += 1;
+            if self.len == PROMOTE_LEN {
+                self.promote();
+            }
+            return true;
+        }
+        let index = id.0 as usize;
+        let word_index = index / WORD_BITS;
+        if word_index >= self.words.len() {
+            self.words.resize(word_index + 1, 0);
+        }
+        let bit = 1 << (index % WORD_BITS);
+        let word = &mut self.words[word_index];
+        if *word & bit != 0 {
+            return false;
+        }
+        *word |= bit;
+        self.len += 1;
+        true
+    }
+
+    #[inline]
+    pub fn remove(&mut self, id: &CharId) -> bool {
+        if !self.dense {
+            let Ok(index) = self.sparse.binary_search(id) else {
+                return false;
+            };
+            self.sparse.remove(index);
+            self.len -= 1;
+            return true;
+        }
+        let index = id.0 as usize;
+        let word_index = index / WORD_BITS;
+        let Some(word) = self.words.get_mut(word_index) else {
+            return false;
+        };
+        let bit = 1 << (index % WORD_BITS);
+        if *word & bit == 0 {
+            return false;
+        }
+        *word &= !bit;
+        self.len -= 1;
+        if word_index + 1 == self.words.len() {
+            while self.words.last() == Some(&0) {
+                self.words.pop();
+            }
+        }
+        if self.len == DEMOTE_LEN {
+            self.demote();
+        }
+        true
+    }
+
+    #[inline]
+    pub fn iter(&self) -> Iter<'_> {
+        Iter {
+            inner: if self.dense {
+                IterInner::Dense {
+                    words: self.words.iter().enumerate(),
+                    remaining: 0,
+                    word_index: 0,
+                }
+            } else {
+                IterInner::Sparse(self.sparse.iter())
+            },
+            len: self.len,
+        }
+    }
+
+    /// Retains elements in the same ascending order in which `BTreeSet`
+    /// invokes its predicate.
+    pub fn retain(&mut self, mut keep: impl FnMut(&CharId) -> bool) {
+        if !self.dense {
+            self.sparse.retain(|id| keep(id));
+            self.len = self.sparse.len();
+            return;
+        }
+        let mut removed = 0;
+        for (word_index, word) in self.words.iter_mut().enumerate() {
+            let mut candidates = *word;
+            while candidates != 0 {
+                let bit_index = candidates.trailing_zeros() as usize;
+                let bit = 1 << bit_index;
+                let id = CharId((word_index * WORD_BITS + bit_index) as u32);
+                if !keep(&id) {
+                    *word &= !bit;
+                    removed += 1;
+                }
+                candidates &= candidates - 1;
+            }
+        }
+        self.len -= removed;
+        while self.words.last() == Some(&0) {
+            self.words.pop();
+        }
+        if self.len <= DEMOTE_LEN {
+            self.demote();
+        }
+    }
+
+    fn promote(&mut self) {
+        let word_len = self
+            .sparse
+            .last()
+            .map_or(0, |id| id.0 as usize / WORD_BITS + 1);
+        self.words.clear();
+        self.words.resize(word_len, 0);
+        for id in self.sparse.drain(..) {
+            let index = id.0 as usize;
+            self.words[index / WORD_BITS] |= 1 << (index % WORD_BITS);
+        }
+        self.dense = true;
+    }
+
+    fn demote(&mut self) {
+        self.sparse.clear();
+        self.sparse.reserve(self.len);
+        for (word_index, &word) in self.words.iter().enumerate() {
+            let mut remaining = word;
+            while remaining != 0 {
+                let bit_index = remaining.trailing_zeros() as usize;
+                self.sparse
+                    .push(CharId((word_index * WORD_BITS + bit_index) as u32));
+                remaining &= remaining - 1;
+            }
+        }
+        self.words.clear();
+        self.dense = false;
+    }
+}
+
+pub struct Iter<'a> {
+    inner: IterInner<'a>,
+    len: usize,
+}
+
+enum IterInner<'a> {
+    Sparse(std::slice::Iter<'a, CharId>),
+    Dense {
+        words: std::iter::Enumerate<std::slice::Iter<'a, u64>>,
+        remaining: u64,
+        word_index: usize,
+    },
+}
+
+impl Iterator for Iter<'_> {
+    type Item = CharId;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let id = match &mut self.inner {
+            IterInner::Sparse(ids) => ids.next().copied(),
+            IterInner::Dense {
+                words,
+                remaining,
+                word_index,
+            } => loop {
+                if *remaining != 0 {
+                    let bit_index = remaining.trailing_zeros() as usize;
+                    *remaining &= *remaining - 1;
+                    break Some(CharId((*word_index * WORD_BITS + bit_index) as u32));
+                }
+                let Some((next_word_index, &word)) = words.next() else {
+                    break None;
+                };
+                *word_index = next_word_index;
+                *remaining = word;
+            },
+        };
+        if id.is_some() {
+            self.len -= 1;
+        }
+        id
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.len, Some(self.len))
+    }
+}
+
+impl ExactSizeIterator for Iter<'_> {}
+
+impl std::iter::FusedIterator for Iter<'_> {}
+
+impl std::fmt::Debug for ActiveCharacters {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.debug_set().entries(self.iter()).finish()
+    }
+}
+
+impl PartialEq for ActiveCharacters {
+    fn eq(&self, other: &Self) -> bool {
+        self.len == other.len && self.iter().eq(other.iter())
+    }
+}
+
+impl Eq for ActiveCharacters {}
+
+impl<'a> IntoIterator for &'a ActiveCharacters {
+    type Item = CharId;
+    type IntoIter = Iter<'a>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl Extend<CharId> for ActiveCharacters {
+    fn extend<T: IntoIterator<Item = CharId>>(&mut self, iter: T) {
+        for id in iter {
+            self.insert(id);
+        }
+    }
+}
+
+impl FromIterator<CharId> for ActiveCharacters {
+    fn from_iter<T: IntoIterator<Item = CharId>>(iter: T) -> Self {
+        let mut characters = Self::new();
+        characters.extend(iter);
+        characters
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn preserves_order_and_set_semantics_across_word_boundaries() {
+        let mut active: ActiveCharacters =
+            [CharId(130), CharId(1), CharId(64), CharId(63), CharId(1)]
+                .into_iter()
+                .collect();
+        assert_eq!(active.len(), 4);
+        assert_eq!(
+            active.iter().collect::<Vec<_>>(),
+            [CharId(1), CharId(63), CharId(64), CharId(130)]
+        );
+        assert!(active.contains(&CharId(64)));
+        assert!(!active.insert(CharId(64)));
+        assert!(active.remove(&CharId(130)));
+        assert!(!active.remove(&CharId(130)));
+
+        let mut visited = Vec::new();
+        active.retain(|id| {
+            visited.push(*id);
+            id.0 % 2 == 1
+        });
+        assert_eq!(visited, [CharId(1), CharId(63), CharId(64)]);
+        assert_eq!(active.iter().collect::<Vec<_>>(), [CharId(1), CharId(63)]);
+
+        active.clear();
+        assert!(active.is_empty());
+        assert_eq!(active.iter().len(), 0);
+    }
+
+    #[test]
+    fn matches_btree_set_through_mixed_operations() {
+        let mut active = ActiveCharacters::new();
+        let mut reference = BTreeSet::new();
+        let mut state = 0x9e37_79b9_u32;
+
+        for step in 0..10_000_u32 {
+            state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+            let id = CharId(state % 4096);
+            match state >> 29 {
+                0..=3 => assert_eq!(active.insert(id), reference.insert(id)),
+                4..=5 => assert_eq!(active.remove(&id), reference.remove(&id)),
+                6 => assert_eq!(active.contains(&id), reference.contains(&id)),
+                _ => {
+                    let modulus = step % 7 + 2;
+                    active.retain(|id| id.0 % modulus != 0);
+                    reference.retain(|id| id.0 % modulus != 0);
+                }
+            }
+
+            if step % 97 == 0 {
+                assert_eq!(active.len(), reference.len());
+                assert_eq!(active.is_empty(), reference.is_empty());
+                assert_eq!(
+                    active.iter().collect::<Vec<_>>(),
+                    reference.iter().copied().collect::<Vec<_>>()
+                );
+            }
+            if step % 997 == 0 {
+                active.clear();
+                reference.clear();
+            }
+        }
+    }
+}

--- a/src/engine/animation.rs
+++ b/src/engine/animation.rs
@@ -195,7 +195,7 @@ impl Scene {
             }
             return Some(ColorCode::Xterm(hexterm::hex_to_xterm(&color.rgb_color)));
         }
-        Some(ColorCode::Rgb(color.rgb_color.clone()))
+        Some(ColorCode::Rgb(color.rgb_color.to_string()))
     }
 
     /// Scene.add_frame with the preexisting-color/bold overrides.
@@ -396,7 +396,7 @@ impl Animation {
             }
             return Some(ColorCode::Xterm(hexterm::hex_to_xterm(&color.rgb_color)));
         }
-        Some(ColorCode::Rgb(color.rgb_color.clone()))
+        Some(ColorCode::Rgb(color.rgb_color.to_string()))
     }
 
     /// Animation.new_scene: auto-ids are stringified integers probing upward;

--- a/src/engine/ctx.rs
+++ b/src/engine/ctx.rs
@@ -9,10 +9,10 @@
 //! by id after every emission point, and segment walks are index-based so
 //! reentrant list mutation behaves like Python list iteration.
 
-use std::collections::BTreeSet;
 use std::rc::Rc;
 use std::time::Instant;
 
+use crate::engine::active_characters::ActiveCharacters;
 use crate::engine::animation::SyncMetric;
 use crate::engine::character::CharId;
 use crate::engine::error::EngineError;
@@ -90,7 +90,7 @@ pub struct EngineCtx {
     pub clock: Clock,
     /// BaseEffectIterator.active_characters — canonical ascending-id order
     /// (CharId order == character_id order by construction).
-    pub active_characters: BTreeSet<CharId>,
+    pub active_characters: ActiveCharacters,
     active_character_scratch: Vec<CharId>,
     pub preexisting_colors_present: bool,
     /// When Some, every event emission appends a trace line (test harness).
@@ -108,7 +108,7 @@ impl EngineCtx {
             terminal,
             rng,
             clock,
-            active_characters: BTreeSet::new(),
+            active_characters: ActiveCharacters::new(),
             active_character_scratch: Vec::new(),
             preexisting_colors_present,
             event_log: None,
@@ -640,7 +640,7 @@ impl EngineCtx {
     pub fn update(&mut self, hooks: &mut dyn EffectHooks) {
         let mut snapshot = std::mem::take(&mut self.active_character_scratch);
         snapshot.clear();
-        snapshot.extend(self.active_characters.iter().copied());
+        snapshot.extend(self.active_characters.iter());
         for &id in &snapshot {
             self.tick(hooks, id);
         }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1,3 +1,4 @@
+pub mod active_characters;
 pub mod animation;
 pub mod canvas;
 pub mod character;

--- a/src/engine/terminal.rs
+++ b/src/engine/terminal.rs
@@ -481,9 +481,9 @@ impl Terminal {
         }
     }
 
-    /// Terminal._update_terminal_state: full repaint, painter's algorithm by
-    /// (layer, character_id) — the canonical deterministic order (plan.md §4.3).
-    pub fn update_terminal_state(&mut self) {
+    /// Paint the visible characters into the reusable cell buffer using the
+    /// canonical (layer, character_id) painter order (plan.md §4.3).
+    fn update_render_cells(&mut self) -> (usize, usize) {
         let width = self.visible_right.max(0) as usize;
         let height = self.visible_top.max(0) as usize;
         let cell_count = width.checked_mul(height).expect("terminal canvas is too large");
@@ -515,6 +515,15 @@ impl Terminal {
             }
         }
 
+        (width, height)
+    }
+
+    /// Terminal._update_terminal_state: materialize the row-oriented state
+    /// exposed by the upstream API. Frame output uses the cell buffer directly
+    /// so the hot path does not copy every rendered byte through these rows.
+    pub fn update_terminal_state(&mut self) {
+        let (width, height) = self.update_render_cells();
+
         self.terminal_state.resize_with(height, String::new);
         self.terminal_state.truncate(height);
         let arena = &self.arena;
@@ -533,21 +542,30 @@ impl Terminal {
         }
     }
 
-    /// get_formatted_output_string: refresh + join top row first.
+    /// get_formatted_output_string: refresh + emit top row first.
     pub fn get_formatted_output_string(&mut self) -> String {
-        self.update_terminal_state();
-        let content_len: usize = self.terminal_state.iter().map(String::len).sum();
-        let required_capacity = content_len + self.terminal_state.len().saturating_sub(1);
+        let (width, height) = self.update_render_cells();
+        let minimum_capacity = width
+            .checked_mul(height)
+            .and_then(|cells| cells.checked_add(height.saturating_sub(1)))
+            .expect("terminal canvas is too large");
         let mut out = std::mem::take(&mut self.output_buffer);
         out.clear();
-        if out.capacity() < required_capacity {
-            out.reserve(required_capacity);
+        if out.capacity() < minimum_capacity {
+            out.reserve(minimum_capacity);
         }
-        for (i, row) in self.terminal_state.iter().rev().enumerate() {
-            if i > 0 {
+        let arena = &self.arena;
+        for row_index in (0..height).rev() {
+            if row_index + 1 < height {
                 out.push('\n');
             }
-            out.push_str(row);
+            for &cell in &self.render_cells[row_index * width..(row_index + 1) * width] {
+                if cell == EMPTY_RENDER_CELL {
+                    out.push(' ');
+                } else {
+                    out.push_str(&arena[cell as usize].animation.current_character_visual.formatted_symbol);
+                }
+            }
         }
         out
     }

--- a/src/engine/terminal.rs
+++ b/src/engine/terminal.rs
@@ -139,6 +139,33 @@ pub struct Terminal {
     last_time_printed: Instant,
 }
 
+fn ordered_buckets(
+    characters: Vec<CharId>,
+    first_key: i64,
+    last_key: i64,
+    mut key: impl FnMut(CharId) -> i64,
+) -> Vec<Vec<CharId>> {
+    if first_key > last_key {
+        return Vec::new();
+    }
+    let bucket_count = last_key
+        .checked_sub(first_key)
+        .and_then(|span| span.checked_add(1))
+        .and_then(|span| usize::try_from(span).ok())
+        .expect("terminal canvas is too large");
+    let expected_bucket_len = characters.len() / bucket_count;
+    let mut buckets: Vec<Vec<CharId>> = (0..bucket_count)
+        .map(|_| Vec::with_capacity(expected_bucket_len))
+        .collect();
+    for id in characters {
+        let character_key = key(id);
+        if first_key <= character_key && character_key <= last_key {
+            buckets[(character_key - first_key) as usize].push(id);
+        }
+    }
+    buckets.into_iter().filter(|bucket| !bucket.is_empty()).collect()
+}
+
 impl Terminal {
     pub fn new(input_data: &str, config: TerminalConfig) -> Result<Self, EngineError> {
         let input_data = if input_data.is_empty() { "No Input." } else { input_data };
@@ -334,7 +361,11 @@ impl Terminal {
     }
 
     pub fn collect_characters(&self, filter: CharacterFilter) -> Vec<CharId> {
-        let mut all: Vec<CharId> = Vec::new();
+        let capacity = if filter.input_chars { self.input_characters.len() } else { 0 }
+            + if filter.inner_fill_chars { self.inner_fill_characters.len() } else { 0 }
+            + if filter.outer_fill_chars { self.outer_fill_characters.len() } else { 0 }
+            + if filter.added_chars { self.added_characters.len() } else { 0 };
+        let mut all: Vec<CharId> = Vec::with_capacity(capacity);
         if filter.input_chars {
             all.extend(&self.input_characters);
         }
@@ -399,84 +430,81 @@ impl Terminal {
         let coord = |id: &CharId| self.arena[id.0 as usize].input_coord;
         match grouping {
             CharacterGroup::ColumnLeftToRight | CharacterGroup::ColumnRightToLeft => {
-                let mut columns: Vec<Vec<CharId>> = Vec::new();
-                for column_index in 0..=self.canvas.right {
-                    let in_column: Vec<CharId> =
-                        all.iter().copied().filter(|id| coord(id).column == column_index).collect();
-                    if !in_column.is_empty() {
-                        columns.push(in_column);
-                    }
-                }
+                let mut columns = ordered_buckets(all, 0, self.canvas.right, |id| coord(&id).column);
                 if grouping == CharacterGroup::ColumnRightToLeft {
                     columns.reverse();
                 }
                 columns
             }
             CharacterGroup::RowBottomToTop | CharacterGroup::RowTopToBottom => {
-                let mut rows: Vec<Vec<CharId>> = Vec::new();
-                for row_index in 0..=self.canvas.top {
-                    let in_row: Vec<CharId> = all.iter().copied().filter(|id| coord(id).row == row_index).collect();
-                    if !in_row.is_empty() {
-                        rows.push(in_row);
-                    }
-                }
+                let mut rows = ordered_buckets(all, 0, self.canvas.top, |id| coord(&id).row);
                 if grouping == CharacterGroup::RowTopToBottom {
                     rows.reverse();
                 }
                 rows
             }
             CharacterGroup::DiagonalBottomLeftToTopRight | CharacterGroup::DiagonalTopRightToBottomLeft => {
-                let mut diagonals: Vec<Vec<CharId>> = Vec::new();
-                for diagonal_index in 0..=(self.canvas.top + self.canvas.right) {
-                    let in_diag: Vec<CharId> = all
-                        .iter()
-                        .copied()
-                        .filter(|id| coord(id).row + coord(id).column == diagonal_index)
-                        .collect();
-                    if !in_diag.is_empty() {
-                        diagonals.push(in_diag);
-                    }
-                }
+                let mut diagonals = ordered_buckets(all, 0, self.canvas.top + self.canvas.right, |id| {
+                    let c = coord(&id);
+                    c.row + c.column
+                });
                 if grouping == CharacterGroup::DiagonalTopRightToBottomLeft {
                     diagonals.reverse();
                 }
                 diagonals
             }
             CharacterGroup::DiagonalTopLeftToBottomRight | CharacterGroup::DiagonalBottomRightToTopLeft => {
-                let mut diagonals: Vec<Vec<CharId>> = Vec::new();
-                for diagonal_index in (self.canvas.left - self.canvas.top)..=(self.canvas.right - self.canvas.bottom) {
-                    let in_diag: Vec<CharId> = all
-                        .iter()
-                        .copied()
-                        .filter(|id| coord(id).column - coord(id).row == diagonal_index)
-                        .collect();
-                    if !in_diag.is_empty() {
-                        diagonals.push(in_diag);
-                    }
-                }
+                let mut diagonals = ordered_buckets(
+                    all,
+                    self.canvas.left - self.canvas.top,
+                    self.canvas.right - self.canvas.bottom,
+                    |id| {
+                        let c = coord(&id);
+                        c.column - c.row
+                    },
+                );
                 if grouping == CharacterGroup::DiagonalBottomRightToTopLeft {
                     diagonals.reverse();
                 }
                 diagonals
             }
             CharacterGroup::CenterToOutside | CharacterGroup::OutsideToCenter => {
-                // insertion-ordered distance map (Python dict semantics)
-                let mut distances: Vec<(i64, Vec<CharId>)> = Vec::new();
-                for &id in &all {
-                    let c = coord(&id);
-                    let distance = (c.column - self.canvas.text_center.column).abs()
-                        + (c.row - self.canvas.text_center.row).abs();
-                    if let Some(entry) = distances.iter_mut().find(|(d, _)| *d == distance) {
-                        entry.1.push(id);
-                    } else {
-                        distances.push((distance, Vec::from([id])));
+                let max_distance = all
+                    .iter()
+                    .map(|&id| {
+                        let c = coord(&id);
+                        (c.column - self.canvas.text_center.column).abs()
+                            + (c.row - self.canvas.text_center.row).abs()
+                    })
+                    .max();
+                let dense_limit = all.len().saturating_mul(4).max(256);
+                let mut groups = if max_distance
+                    .and_then(|distance| usize::try_from(distance).ok())
+                    .is_some_and(|distance| distance <= dense_limit)
+                {
+                    ordered_buckets(all, 0, max_distance.unwrap(), |id| {
+                        let c = coord(&id);
+                        (c.column - self.canvas.text_center.column).abs()
+                            + (c.row - self.canvas.text_center.row).abs()
+                    })
+                } else {
+                    // Out-of-canvas added characters can have sparse, arbitrarily
+                    // large distances; avoid allocating through the largest key.
+                    let mut distances: HashMap<i64, Vec<CharId>> = HashMap::new();
+                    for id in all {
+                        let c = coord(&id);
+                        let distance = (c.column - self.canvas.text_center.column).abs()
+                            + (c.row - self.canvas.text_center.row).abs();
+                        distances.entry(distance).or_default().push(id);
                     }
-                }
-                distances.sort_by_key(|&(d, _)| d);
+                    let mut distances: Vec<(i64, Vec<CharId>)> = distances.into_iter().collect();
+                    distances.sort_by_key(|&(distance, _)| distance);
+                    distances.into_iter().map(|(_, group)| group).collect()
+                };
                 if grouping == CharacterGroup::OutsideToCenter {
-                    distances.reverse();
+                    groups.reverse();
                 }
-                distances.into_iter().map(|(_, group)| group).collect()
+                groups
             }
         }
     }

--- a/src/utils/easing.rs
+++ b/src/utils/easing.rs
@@ -326,55 +326,47 @@ impl EasingTracker {
 
 /// easing.SequenceEaser over owned elements (effects use it over id groups).
 #[derive(Debug, Clone)]
-pub struct SequenceEaser<T: Clone> {
+pub struct SequenceEaser<T> {
     pub sequence: Vec<T>,
     pub easing_tracker: EasingTracker,
-    pub added: Vec<T>,
-    pub removed: Vec<T>,
-    pub total: Vec<T>,
 }
 
-impl<T: Clone> SequenceEaser<T> {
+#[derive(Debug, Clone, Copy)]
+pub struct SequenceStep<'a, T> {
+    pub added: &'a [T],
+    pub removed: &'a [T],
+}
+
+impl<T> SequenceEaser<T> {
     pub fn new(sequence: Vec<T>, easing_function: Easing, total_steps: i64) -> Self {
         SequenceEaser {
             sequence,
             easing_tracker: EasingTracker::new(easing_function, total_steps, true),
-            added: Vec::new(),
-            removed: Vec::new(),
-            total: Vec::new(),
         }
     }
 
-    pub fn step(&mut self) -> &[T] {
+    pub fn step(&mut self) -> SequenceStep<'_, T> {
         let previous_eased = self.easing_tracker.eased_value;
         let eased_value = self.easing_tracker.step();
         let seq_len = self.sequence.len();
         if seq_len == 0 {
-            self.added.clear();
-            self.removed.clear();
-            self.total.clear();
-            return &self.added;
+            return SequenceStep { added: &[], removed: &[] };
         }
         // int() truncation, faithfully
         let length = (eased_value * seq_len as f64) as i64 as usize;
         let previous_length = (previous_eased * seq_len as f64) as i64 as usize;
 
         match length.cmp(&previous_length) {
-            std::cmp::Ordering::Greater => {
-                self.added = self.sequence[previous_length..length].to_vec();
-                self.removed.clear();
-            }
-            std::cmp::Ordering::Less => {
-                self.added.clear();
-                self.removed = self.sequence[length..previous_length].to_vec();
-            }
-            std::cmp::Ordering::Equal => {
-                self.added.clear();
-                self.removed.clear();
-            }
+            std::cmp::Ordering::Greater => SequenceStep {
+                added: &self.sequence[previous_length..length],
+                removed: &[],
+            },
+            std::cmp::Ordering::Less => SequenceStep {
+                added: &[],
+                removed: &self.sequence[length..previous_length],
+            },
+            std::cmp::Ordering::Equal => SequenceStep { added: &[], removed: &[] },
         }
-        self.total = self.sequence[..length].to_vec();
-        &self.added
     }
 
     pub fn is_complete(&self) -> bool {
@@ -383,8 +375,46 @@ impl<T: Clone> SequenceEaser<T> {
 
     pub fn reset(&mut self) {
         self.easing_tracker.reset();
-        self.added.clear();
-        self.removed.clear();
-        self.total.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Easing, SequenceEaser};
+
+    #[derive(Debug, PartialEq)]
+    struct NonClone(u8);
+
+    #[test]
+    fn sequence_easer_returns_borrowed_deltas_without_clone() {
+        let mut easer = SequenceEaser::new(
+            vec![NonClone(0), NonClone(1), NonClone(2), NonClone(3)],
+            Easing::Linear,
+            4,
+        );
+
+        assert_eq!(easer.step().added, &[NonClone(0)]);
+        assert_eq!(easer.step().added, &[NonClone(1)]);
+        assert_eq!(easer.step().added, &[NonClone(2)]);
+        assert_eq!(easer.step().added, &[NonClone(3)]);
+        assert!(easer.step().added.is_empty());
+
+        easer.reset();
+        assert_eq!(easer.step().added, &[NonClone(0)]);
+    }
+
+    #[test]
+    fn sequence_easer_reports_reversed_easing_as_removed() {
+        let sequence: Vec<usize> = (0..100).collect();
+        let mut easer = SequenceEaser::new(sequence, Easing::OutBounce, 100);
+        let mut saw_removed = false;
+
+        for _ in 0..100 {
+            let step = easer.step();
+            assert!(step.added.is_empty() || step.removed.is_empty());
+            saw_removed |= !step.removed.is_empty();
+        }
+
+        assert!(saw_removed);
     }
 }

--- a/src/utils/geometry.rs
+++ b/src/utils/geometry.rs
@@ -30,6 +30,16 @@ struct FloatPoint {
     row: f64,
 }
 
+impl FloatPoint {
+    #[inline]
+    fn interpolate(self, other: Self, t: f64) -> Self {
+        FloatPoint {
+            column: (1.0 - t) * self.column + t * other.column,
+            row: (1.0 - t) * self.row + t * other.row,
+        }
+    }
+}
+
 /// find_coords_on_circle: coords_limit 0 -> round(2*pi*r); x offset from the
 /// origin is doubled for cell aspect; every point rounded (banker's).
 pub fn find_coords_on_circle(origin: Coord, radius: i64, coords_limit: i64, unique: bool) -> Vec<Coord> {
@@ -133,21 +143,33 @@ pub fn extrapolate_along_ray(origin: Coord, target: Coord, offset_from_target: f
 /// find_coord_on_bezier_curve: recursive De Casteljau of arbitrary degree with
 /// float intermediates, rounded only at the end.
 pub fn find_coord_on_bezier_curve(start: Coord, control: &[Coord], end: Coord, t: f64) -> Coord {
+    if control.is_empty() {
+        return find_coord_on_line(start, end, t);
+    }
+
+    let start = FloatPoint { column: start.column as f64, row: start.row as f64 };
+    let end = FloatPoint { column: end.column as f64, row: end.row as f64 };
+
+    // Every production path is quadratic. Keep that per-frame hot path on the
+    // stack instead of allocating a Vec at each De Casteljau level.
+    if let [control] = control {
+        let control = FloatPoint { column: control.column as f64, row: control.row as f64 };
+        let point = start.interpolate(control, t).interpolate(control.interpolate(end, t), t);
+        return Coord::new(round_half_even(point.column), round_half_even(point.row));
+    }
+
     let mut points: Vec<FloatPoint> = Vec::with_capacity(control.len() + 2);
-    points.push(FloatPoint { column: start.column as f64, row: start.row as f64 });
+    points.push(start);
     for c in control {
         points.push(FloatPoint { column: c.column as f64, row: c.row as f64 });
     }
-    points.push(FloatPoint { column: end.column as f64, row: end.row as f64 });
-    while points.len() > 1 {
-        let mut next: Vec<FloatPoint> = Vec::with_capacity(points.len() - 1);
-        for i in 0..points.len() - 1 {
-            next.push(FloatPoint {
-                column: (1.0 - t) * points[i].column + t * points[i + 1].column,
-                row: (1.0 - t) * points[i].row + t * points[i + 1].row,
-            });
+    points.push(end);
+    let mut remaining = points.len();
+    while remaining > 1 {
+        for i in 0..remaining - 1 {
+            points[i] = points[i].interpolate(points[i + 1], t);
         }
-        points = next;
+        remaining -= 1;
     }
     Coord::new(round_half_even(points[0].column), round_half_even(points[0].row))
 }

--- a/src/utils/graphics.rs
+++ b/src/utils/graphics.rs
@@ -1,6 +1,8 @@
 //! Color, ColorPair, and Gradient, ported from utils/graphics.py.
 
 use std::collections::HashMap;
+use std::fmt;
+use std::ops::Deref;
 
 use crate::utils::geometry::{self, Coord};
 use crate::utils::hexterm;
@@ -10,19 +12,86 @@ use crate::utils::rng::Rng;
 /// The original constructor argument, preserved because upstream `Color.__eq__`
 /// and `__hash__` compare `color_arg` — `Color(255) != Color("ffffff")` even
 /// when they resolve to the same RGB. Dict/set keying depends on this.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ColorArg {
     Xterm(u8),
-    Hex(String), // stored stripped of '#', case preserved (upstream strips '#' only)
+    Hex(RgbString), // stored stripped of '#', case preserved (upstream strips '#' only)
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct RgbString {
+    bytes: [u8; 7],
+    len: u8,
+}
+
+impl RgbString {
+    fn new(value: &str) -> Self {
+        debug_assert!(value.len() <= 7);
+        let mut bytes = [0; 7];
+        bytes[..value.len()].copy_from_slice(value.as_bytes());
+        RgbString {
+            bytes,
+            len: value.len() as u8,
+        }
+    }
+}
+
+impl Deref for RgbString {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        std::str::from_utf8(&self.bytes[..self.len as usize]).unwrap()
+    }
+}
+
+impl AsRef<str> for RgbString {
+    fn as_ref(&self) -> &str {
+        self
+    }
+}
+
+impl std::borrow::Borrow<str> for RgbString {
+    fn borrow(&self) -> &str {
+        self
+    }
+}
+
+impl std::hash::Hash for RgbString {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        std::hash::Hash::hash(&**self, state);
+    }
+}
+
+impl fmt::Display for RgbString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self)
+    }
+}
+
+impl fmt::Debug for RgbString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&**self, f)
+    }
+}
+
+#[derive(Clone, Copy)]
 pub struct Color {
     pub color_arg: ColorArg,
     /// Some(code) when constructed from an xterm int, None for hex strings.
     pub xterm_color: Option<u8>,
     /// hex string without '#'
-    pub rgb_color: String,
+    pub rgb_color: RgbString,
+    rgb: [u8; 3],
+}
+
+impl fmt::Debug for Color {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Color")
+            .field("color_arg", &self.color_arg)
+            .field("xterm_color", &self.xterm_color)
+            .field("rgb_color", &self.rgb_color)
+            .finish()
+    }
 }
 
 impl PartialEq for Color {
@@ -39,10 +108,12 @@ impl std::hash::Hash for Color {
 
 impl Color {
     pub fn from_xterm(code: u8) -> Self {
+        let rgb_color = RgbString::new(hexterm::xterm_to_hex(code));
         Color {
             color_arg: ColorArg::Xterm(code),
             xterm_color: Some(code),
-            rgb_color: hexterm::xterm_to_hex(code).to_string(),
+            rgb: Self::parse_rgb(&rgb_color),
+            rgb_color,
         }
     }
 
@@ -56,24 +127,29 @@ impl Color {
                     .to_string(),
             );
         }
+        let rgb_color = RgbString::new(stripped);
         Ok(Color {
-            color_arg: ColorArg::Hex(stripped.to_string()),
+            color_arg: ColorArg::Hex(rgb_color),
             xterm_color: None,
-            rgb_color: stripped.to_string(),
+            rgb: Self::parse_rgb(&rgb_color),
+            rgb_color,
         })
     }
 
     pub fn rgb_ints(&self) -> (u8, u8, u8) {
-        let s = &self.rgb_color;
-        (
+        (self.rgb[0], self.rgb[1], self.rgb[2])
+    }
+
+    fn parse_rgb(s: &str) -> [u8; 3] {
+        [
             u8::from_str_radix(&s[0..2], 16).unwrap(),
             u8::from_str_radix(&s[2..4], 16).unwrap(),
             u8::from_str_radix(&s[4..6], 16).unwrap(),
-        )
+        ]
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub struct ColorPair {
     pub fg_color: Option<Color>,
     pub bg_color: Option<Color>,
@@ -296,4 +372,28 @@ pub fn shift_color_towards(color: &Color, target_color: &Color, factor: f64) -> 
         py_hex(interpolate(cb, tb, factor))
     );
     Color::from_hex(&hex)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::Color;
+
+    #[test]
+    fn rgb_string_borrowed_lookup_matches_str_hash() {
+        let rgb = Color::from_hex("12AbEf7").unwrap().rgb_color;
+        let mut colors = HashMap::new();
+        colors.insert(rgb, 1);
+        assert_eq!(colors.get("12AbEf7"), Some(&1));
+    }
+
+    #[test]
+    fn color_debug_hides_the_cached_representation() {
+        let color = Color::from_hex("12AbEf7").unwrap();
+        assert_eq!(
+            format!("{color:?}"),
+            "Color { color_arg: Hex(\"12AbEf7\"), xterm_color: None, rgb_color: \"12AbEf7\" }"
+        );
+    }
 }

--- a/src/utils/hexterm.rs
+++ b/src/utils/hexterm.rs
@@ -1,36 +1,67 @@
 //! xterm-256 <-> RGB conversion, ported from utils/hexterm.py.
 
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
 include!("hexterm_table.rs");
 
-/// RGB ints for an xterm code, derived from XTERM_TO_HEX like upstream's xterm_to_rgb_map.
-fn xterm_rgb(code: usize) -> (i64, i64, i64) {
-    let h = XTERM_TO_HEX[code];
-    (
-        i64::from_str_radix(&h[0..2], 16).unwrap(),
-        i64::from_str_radix(&h[2..4], 16).unwrap(),
-        i64::from_str_radix(&h[4..6], 16).unwrap(),
-    )
+type Rgb = [u8; 3];
+
+static XTERM_RGB: OnceLock<[Rgb; 256]> = OnceLock::new();
+
+thread_local! {
+    /// Scene and Animation both memoize this conversion upstream. Keeping the
+    /// memo here also covers callers outside the animation engine and lets all
+    /// scenes on the render thread share the same results.
+    static HEX_TO_XTERM_CACHE: RefCell<HashMap<u32, u8>> = RefCell::new(HashMap::new());
 }
 
-/// Closest xterm-256 code by mean absolute channel difference; linear scan over
-/// codes 0..=255 in order, strict `<` so the first minimum wins (upstream
-/// hexterm.py hex_to_xterm).
-pub fn hex_to_xterm(hex_color: &str) -> u8 {
+fn parse_rgb(hex_color: &str) -> Rgb {
     let s = hex_color.trim_matches('#');
-    let r = i64::from_str_radix(&s[0..2], 16).unwrap();
-    let g = i64::from_str_radix(&s[2..4], 16).unwrap();
-    let b = i64::from_str_radix(&s[4..6], 16).unwrap();
-    let mut min_diff = f64::INFINITY;
+    [
+        u8::from_str_radix(&s[0..2], 16).unwrap(),
+        u8::from_str_radix(&s[2..4], 16).unwrap(),
+        u8::from_str_radix(&s[4..6], 16).unwrap(),
+    ]
+}
+
+/// Parse the generated palette once rather than reparsing all 768 channels on
+/// every conversion.
+fn xterm_rgb() -> &'static [Rgb; 256] {
+    XTERM_RGB.get_or_init(|| std::array::from_fn(|code| parse_rgb(XTERM_TO_HEX[code])))
+}
+
+fn closest_xterm([r, g, b]: Rgb) -> u8 {
+    let mut min_diff = u16::MAX;
     let mut closest = 0u8;
-    for code in 0..256usize {
-        let (xr, xg, xb) = xterm_rgb(code);
-        let diff = ((r - xr).abs() + (g - xg).abs() + (b - xb).abs()) as f64 / 3.0;
+    for (code, &[xr, xg, xb]) in xterm_rgb().iter().enumerate() {
+        // Upstream divides this sum by three before comparing it. Division by
+        // the same positive constant is order-preserving, so comparing the
+        // integer sums retains its strict-first-minimum tie behavior exactly.
+        let diff = r.abs_diff(xr) as u16 + g.abs_diff(xg) as u16 + b.abs_diff(xb) as u16;
         if diff < min_diff {
             min_diff = diff;
             closest = code as u8;
         }
     }
     closest
+}
+
+/// Closest xterm-256 code by mean absolute channel difference; linear scan over
+/// codes 0..=255 in order, strict `<` so the first minimum wins (upstream
+/// hexterm.py hex_to_xterm).
+pub fn hex_to_xterm(hex_color: &str) -> u8 {
+    let rgb = parse_rgb(hex_color);
+    let key = u32::from_be_bytes([0, rgb[0], rgb[1], rgb[2]]);
+    HEX_TO_XTERM_CACHE.with(|cache| {
+        if let Some(cached) = cache.borrow().get(&key).copied() {
+            return cached;
+        }
+        let closest = closest_xterm(rgb);
+        cache.borrow_mut().insert(key, closest);
+        closest
+    })
 }
 
 /// xterm code -> hex string without leading '#'.
@@ -52,12 +83,54 @@ pub fn is_valid_hex_color(color: &str) -> bool {
 mod tests {
     use super::*;
 
+    fn reference_hex_to_xterm(hex_color: &str) -> u8 {
+        let [r, g, b] = parse_rgb(hex_color).map(i64::from);
+        let mut min_diff = f64::INFINITY;
+        let mut closest = 0u8;
+        for (code, hex) in XTERM_TO_HEX.iter().enumerate() {
+            let [xr, xg, xb] = parse_rgb(hex).map(i64::from);
+            let diff = ((r - xr).abs() + (g - xg).abs() + (b - xb).abs()) as f64 / 3.0;
+            if diff < min_diff {
+                min_diff = diff;
+                closest = code as u8;
+            }
+        }
+        closest
+    }
+
     #[test]
     fn table_spot_checks() {
         // Golden values from the pinned reference
         assert_eq!(xterm_to_hex(0), "000000");
         assert_eq!(xterm_to_hex(15), "ffffff");
         assert_eq!(xterm_to_hex(196), "ff0000");
+    }
+
+    #[test]
+    fn cached_conversion_matches_reference_across_rgb_space() {
+        // Include exact palette boundaries, neighboring values, and mixed-case
+        // spelling. This exercises ties as well as ordinary nearest colors.
+        let channels = [
+            0u8, 1, 14, 15, 16, 31, 47, 63, 79, 95, 127, 128, 159, 191, 223, 254, 255,
+        ];
+        for &r in &channels {
+            for &g in &channels {
+                for &b in &channels {
+                    let hex = format!("#{r:02X}{g:02x}{b:02X}");
+                    assert_eq!(hex_to_xterm(&hex), reference_hex_to_xterm(&hex), "{hex}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn repeated_and_equivalent_spellings_share_the_exact_result() {
+        let expected = reference_hex_to_xterm("ff00aa");
+        assert_eq!(hex_to_xterm("ff00aa"), expected);
+        assert_eq!(hex_to_xterm("#FF00AA"), expected);
+        // Seven digits are accepted elsewhere and the existing converter uses
+        // its first six, a compatibility quirk worth keeping explicit.
+        assert_eq!(hex_to_xterm("ff00aa7"), expected);
     }
 
     #[test]

--- a/tests/terminal_grouping.rs
+++ b/tests/terminal_grouping.rs
@@ -1,0 +1,174 @@
+use ttfx::engine::character::CharId;
+use ttfx::engine::terminal::{CharacterFilter, CharacterGroup, Terminal, TerminalConfig};
+use ttfx::utils::geometry::Coord;
+
+const GROUPINGS: [CharacterGroup; 10] = [
+    CharacterGroup::ColumnLeftToRight,
+    CharacterGroup::ColumnRightToLeft,
+    CharacterGroup::RowTopToBottom,
+    CharacterGroup::RowBottomToTop,
+    CharacterGroup::DiagonalBottomLeftToTopRight,
+    CharacterGroup::DiagonalTopRightToBottomLeft,
+    CharacterGroup::DiagonalTopLeftToBottomRight,
+    CharacterGroup::DiagonalBottomRightToTopLeft,
+    CharacterGroup::CenterToOutside,
+    CharacterGroup::OutsideToCenter,
+];
+
+fn reference_grouping(
+    terminal: &Terminal,
+    filter: CharacterFilter,
+    grouping: CharacterGroup,
+) -> Vec<Vec<CharId>> {
+    let mut all = terminal.collect_characters(filter);
+    all.sort_by_key(|&id| {
+        let c = terminal.arena[id.0 as usize].input_coord;
+        (c.row, c.column)
+    });
+    let coord = |id: &CharId| terminal.arena[id.0 as usize].input_coord;
+    match grouping {
+        CharacterGroup::ColumnLeftToRight | CharacterGroup::ColumnRightToLeft => {
+            let mut groups = Vec::new();
+            for key in 0..=terminal.canvas.right {
+                let group = all.iter().copied().filter(|id| coord(id).column == key).collect::<Vec<_>>();
+                if !group.is_empty() {
+                    groups.push(group);
+                }
+            }
+            if grouping == CharacterGroup::ColumnRightToLeft {
+                groups.reverse();
+            }
+            groups
+        }
+        CharacterGroup::RowBottomToTop | CharacterGroup::RowTopToBottom => {
+            let mut groups = Vec::new();
+            for key in 0..=terminal.canvas.top {
+                let group = all.iter().copied().filter(|id| coord(id).row == key).collect::<Vec<_>>();
+                if !group.is_empty() {
+                    groups.push(group);
+                }
+            }
+            if grouping == CharacterGroup::RowTopToBottom {
+                groups.reverse();
+            }
+            groups
+        }
+        CharacterGroup::DiagonalBottomLeftToTopRight | CharacterGroup::DiagonalTopRightToBottomLeft => {
+            let mut groups = Vec::new();
+            for key in 0..=(terminal.canvas.top + terminal.canvas.right) {
+                let group = all
+                    .iter()
+                    .copied()
+                    .filter(|id| {
+                        let c = coord(id);
+                        c.row + c.column == key
+                    })
+                    .collect::<Vec<_>>();
+                if !group.is_empty() {
+                    groups.push(group);
+                }
+            }
+            if grouping == CharacterGroup::DiagonalTopRightToBottomLeft {
+                groups.reverse();
+            }
+            groups
+        }
+        CharacterGroup::DiagonalTopLeftToBottomRight | CharacterGroup::DiagonalBottomRightToTopLeft => {
+            let mut groups = Vec::new();
+            for key in
+                (terminal.canvas.left - terminal.canvas.top)..=(terminal.canvas.right - terminal.canvas.bottom)
+            {
+                let group = all
+                    .iter()
+                    .copied()
+                    .filter(|id| {
+                        let c = coord(id);
+                        c.column - c.row == key
+                    })
+                    .collect::<Vec<_>>();
+                if !group.is_empty() {
+                    groups.push(group);
+                }
+            }
+            if grouping == CharacterGroup::DiagonalBottomRightToTopLeft {
+                groups.reverse();
+            }
+            groups
+        }
+        CharacterGroup::CenterToOutside | CharacterGroup::OutsideToCenter => {
+            let mut distances: Vec<(i64, Vec<CharId>)> = Vec::new();
+            for id in all {
+                let c = coord(&id);
+                let distance = (c.column - terminal.canvas.text_center.column).abs()
+                    + (c.row - terminal.canvas.text_center.row).abs();
+                if let Some((_, group)) = distances.iter_mut().find(|(key, _)| *key == distance) {
+                    group.push(id);
+                } else {
+                    distances.push((distance, vec![id]));
+                }
+            }
+            distances.sort_by_key(|(distance, _)| *distance);
+            if grouping == CharacterGroup::OutsideToCenter {
+                distances.reverse();
+            }
+            distances.into_iter().map(|(_, group)| group).collect()
+        }
+    }
+}
+
+#[test]
+fn direct_buckets_match_scan_grouping_order_and_bounds() {
+    let mut terminal = Terminal::new(
+        "A C\n DE\nF G",
+        TerminalConfig {
+            canvas_width: 8,
+            canvas_height: 6,
+            ignore_terminal_dimensions: true,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    for coord in [
+        Coord::new(0, 0),
+        Coord::new(-5, 2),
+        Coord::new(2, 99),
+        Coord::new(1, 3),
+        Coord::new(1, 3),
+        Coord::new(99, 99),
+    ] {
+        terminal.add_character("+", coord);
+    }
+
+    let filters = [
+        CharacterFilter::default(),
+        CharacterFilter {
+            input_chars: true,
+            inner_fill_chars: true,
+            outer_fill_chars: true,
+            added_chars: true,
+        },
+        CharacterFilter {
+            input_chars: false,
+            inner_fill_chars: false,
+            outer_fill_chars: false,
+            added_chars: true,
+        },
+        CharacterFilter {
+            input_chars: false,
+            inner_fill_chars: false,
+            outer_fill_chars: false,
+            added_chars: false,
+        },
+    ];
+
+    for filter in filters {
+        for grouping in GROUPINGS {
+            assert_eq!(
+                terminal.get_characters_grouped(filter, grouping),
+                reference_grouping(&terminal, filter, grouping),
+                "grouping {grouping:?} diverged"
+            );
+        }
+    }
+}


### PR DESCRIPTION
This PR completes the FPS autoresearch pass with eleven separately measured optimization commits.

## Combined result

Pinned-core, alternating-order benchmark against `master` (`ca54938`), using 11 samples per effect on the established 100x30 corpus:

- Aggregate FPS across all 35 non-clock effects: 19,873.98 -> 23,305.04 (+17.26%)
- Geometric-mean per-effect speedup: 1.185x
- Median per-effect speedup: 1.178x
- Total median runtime: 1299.337 -> 1108.044 ms (-14.72%)
- Faster effects: 35 of 35
- Complete frame streams: byte-identical for 35 of 35 effects

A dense 200x50 comparison across Beams, Waves, Colorshift, Highlight, Expand, and Middleout improved aggregate FPS by 32.49%. All six complete streams remained byte-identical.

## Accepted wins

- Render directly from the reusable cell buffer, removing a full-frame copy.
- Evaluate quadratic Bezier paths without per-frame heap allocation.
- Parse the xterm palette once and memoize RGB conversions. Sampled xterm workloads improved 3.17x to 6.61x.
- Initialize Beams character scenes once. Standard FPS improved 2.151x in the final combined benchmark; dense FPS improved 1.985x.
- Skip unchanged Matrix rain visuals while preserving RNG draws. Isolated 200x50 runs improved 1.86x to 5.68x depending on color mode.
- Borrow SequenceEaser deltas instead of cloning cumulative character sets.
- Reuse the Overflow queue and borrow gradient state.
- Abort on panic in release builds. The final release binary is about 31% smaller than the original master binary.
- Store RGB colors inline with cached parsed channels. This alone delivered +11.6% geometric-mean FPS across 35 effects.
- Use an adaptive sorted-vector/bitmap active-character set. Dense effects improved roughly 6% to 14%.
- Bucket character groups in one pass. The grouping primitive improved 7.03x overall, with Matrix first-frame build improving 5.2%.

## Validation

- `cargo test --release`: 23 tests passed across unit and integration suites
- Effect parity: 354 passed, 0 failed
- Terminal byte-stream parity: 41 passed, 0 failed
- CLI corpus: 19 passed, 0 failed
- GitHub CI: Linux tests/parity, macOS tests, and static musl binary all passed
- `git diff --check`: clean

## Compatibility note

The compact RGB representation changes the public Rust field types from heap-backed strings to `RgbString` and prevents external `Color` struct literals. The project is binary-focused; command behavior and rendered output remain byte-identical.