### PR TITLE
README: retally the numbers after the dispatch and render work

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ TTE is MIT licensed and so is this port; the original copyright is preserved in
 ## Why a port
 
 TTE is a Python package. That's the right call for a library, but for a shell toy that lives in
-your prompt pipeline it means an interpreter, an install step, and ~85 ms of import before the
-first frame. ttfx is one dependency-free binary that starts in ~1 ms.
+your prompt pipeline it means an interpreter, an install step, and ~65 ms of import before the
+first frame. ttfx is one dependency-free binary that starts in half a millisecond.
 
 That difference is the whole reason this exists. On a fullscreen canvas the heavier effects run
 out of headroom under Python. Time to render a whole animation, pacing disabled so this measures
@@ -33,15 +33,17 @@ throughput rather than `sleep()`:
 
 | At 200×50 cells | frames | ttfx | Python TTE | ttfx fps |
 |---|---|---|---|---|
-| slide | 375 | 147 ms | 2,417 ms | 2,557 |
-| beams | 732 | 345 ms | 5,471 ms | 2,123 |
-| rings | 1,566 | 1,492 ms | 12,512 ms | 1,050 |
-| waves | 633 | 1,082 ms | 9,157 ms | 585 |
-| startup | — | 0.9 ms | 83 ms | — |
+| slide | 375 | 76 ms | 2,203 ms | 4,930 |
+| beams | 732 | 181 ms | 5,564 ms | 4,050 |
+| rings | 1,566 | 521 ms | 10,439 ms | 3,004 |
+| waves | 633 | 374 ms | 8,745 ms | 1,693 |
+| startup | — | 0.5 ms | 64 ms | — |
 
-Across the 35 effects that aren't gated on wall-clock time, the median speedup is **14.1×**
-(range 6.3×–26.6×). The two that are gated — `matrix` and `thunderstorm` — render 2.1× and 1.2×
-the frames in the same seconds instead of finishing sooner.
+Across the 35 effects that aren't gated on wall-clock time, the median speedup is **27.5×**
+(range 17.1×–47.4×). The two that are gated — `matrix` and `thunderstorm` — spend most of their
+runtime in a fixed animation duration that no implementation can shorten, so they come in at
+1.9× and 1.3×; what ttfx buys there is a far higher frame rate inside that window, not a shorter
+one.
 
 Reproduce it with `python3 tools/tests/bench_full.py`, or set `TTFX_BENCH_COLS`, `TTFX_BENCH_LINES`
 and `TTFX_BENCH_FILL=1` for the fullscreen numbers above. Both sides run their real user-facing


### PR DESCRIPTION
Re-measured against the pinned upstream reference on a fullscreen canvas with
PR #5 merged, using the repo's own harness:

```
TTFX_BENCH_COLS=200 TTFX_BENCH_LINES=50 TTFX_BENCH_FILL=1 python3 tools/tests/bench_full.py 5
```

| | was | now |
|---|---|---|
| median speedup (35 work-bound effects) | 14.1× | **27.5×** |
| range | 6.3×–26.6× | 17.1×–47.4× |
| rings | 1,492 ms | 521 ms |
| waves | 1,082 ms | 374 ms |
| beams | 345 ms | 181 ms |
| slide | 147 ms | 76 ms |
| startup | 0.9 ms | 0.5 ms |

## One correction beyond the numbers

The clock-bound sentence said `matrix` and `thunderstorm` "render 2.1× and 1.2×
the frames in the same seconds." That isn't what the harness measures — it times
Python but never counts Python's frames, so the ratio in that column is wall
clock, and the two sides don't run for equal durations anyway (matrix: 15.1 s
vs 28.9 s). I rewrote the sentence to say what the number is: most of their
runtime is a fixed animation duration neither implementation can shorten, which
is why they come in at 1.9× and 1.3×.

I did try to measure the frame counts directly, by counting the per-frame
DEC-restore-cursor in each side's tty stream. It works, but with pacing off the
reader becomes the bottleneck, so the counts measure the pipe rather than the
renderer — and the ttfx run filled a 31 GB tmpfs on the way. Not a number worth
publishing, so the README no longer claims one.

— 🤖 Claude, posting on behalf of @dhh