### PR TITLE
Stop dumping core when the terminal goes away

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -18,6 +18,7 @@ cargo test --release
 "$ROOT/bin/build"
 ./tools/tests/cli_corpus.sh
 python3 tools/tests/sigterm_behavior.py
+python3 tools/tests/terminal_close_behavior.py
 
 # Bit-exact parity is pinned to Linux/glibc (plan.md §5.20) — elsewhere the
 # reference was never promised to match. The resize suite goes with it: its

--- a/src/engine/effect.rs
+++ b/src/engine/effect.rs
@@ -19,53 +19,75 @@ pub enum RunOutcome {
     Interrupted,
     Terminated,
     TerminalResized,
+    /// The terminal went away mid-run — see [`output_closed`].
+    OutputClosed,
 }
 
 /// __main__ run loop with terminal_output(): prep canvas, stream frames,
 /// always restore the cursor (even on error — RAII would not run on a raw
 /// process exit, so this is explicit).
 ///
-/// With `stop_on_resize`, a settled terminal resize also ends the pass, wiped
-/// and parked at the top of the area so the caller can rebuild in place.
+/// On a tty a settled terminal resize also ends the pass, wiped and parked at
+/// the top of the area so the caller can rebuild in place, and a terminal that
+/// goes away ends the run. A redirected stream gets neither: SIGWINCH there is
+/// not about our output, and a write that fails to a file is a real failure.
 pub fn run_effect(
     effect: &mut dyn Effect,
     ctx: &mut EngineCtx,
-    stop_on_resize: bool,
+    tty_output: bool,
 ) -> Result<RunOutcome, EngineError> {
     effect.build(ctx)?;
     let stdout = std::io::stdout();
     let mut out = stdout.lock();
-    ctx.terminal.prep_canvas(&mut out).map_err(io_err)?;
     let mut outcome = RunOutcome::Complete;
-    let result = (|| {
+    let result = (|| -> std::io::Result<()> {
+        ctx.terminal.prep_canvas(&mut out)?;
         loop {
-            if let Some(stop) = requested_stop(ctx, stop_on_resize) {
+            if let Some(stop) = requested_stop(ctx, tty_output) {
                 outcome = stop;
                 break;
             }
             let Some(frame) = effect.next_frame(ctx) else {
                 break;
             };
-            if let Some(stop) = requested_stop(ctx, stop_on_resize) {
+            if let Some(stop) = requested_stop(ctx, tty_output) {
                 outcome = stop;
                 ctx.terminal.recycle_output_string(frame);
                 break;
             }
-            ctx.terminal.print_frame(&mut out, &frame).map_err(io_err)?;
+            ctx.terminal.print_frame(&mut out, &frame)?;
             ctx.terminal.recycle_output_string(frame);
         }
         Ok(())
     })();
-    if outcome == RunOutcome::TerminalResized {
+    let teardown = if outcome == RunOutcome::TerminalResized {
         // Leave the cursor hidden and parked at the top of the wiped area: the
         // rebuild redraws in place, and showing the cursor here would strobe it
         // dozens of times a second through a window drag.
-        ctx.terminal.reset_canvas_area(&mut out).map_err(io_err)?;
+        ctx.terminal.reset_canvas_area(&mut out)
     } else {
-        ctx.terminal.restore_cursor(&mut out, "\n").map_err(io_err)?;
-    }
+        ctx.terminal.restore_cursor(&mut out, "\n")
+    };
     out.flush().ok();
-    result.map(|_| outcome)
+    match result.and(teardown) {
+        Ok(()) => Ok(outcome),
+        Err(e) if tty_output && output_closed(&e) => Ok(RunOutcome::OutputClosed),
+        Err(e) => Err(io_err(e)),
+    }
+}
+
+/// The terminal an animation is drawing on can go away mid-frame: the
+/// screensaver's window is killed at lock, an emulator exits, a reader closes
+/// the pipe. Every write after that fails, teardown included, and there is no
+/// cursor left to restore — so this ends the run instead of raising an error
+/// nobody can be told about (basecamp/omarchy#6762).
+///
+/// EIO is the pty slave outliving its master; EPIPE only surfaces here when
+/// SIGPIPE was ignored by whoever started us, since we restore its default.
+/// Both mean the same thing, and neither is a failure of this run.
+fn output_closed(e: &std::io::Error) -> bool {
+    const EIO: i32 = 5;
+    e.kind() == std::io::ErrorKind::BrokenPipe || e.raw_os_error() == Some(EIO)
 }
 
 fn requested_stop(ctx: &mut EngineCtx, stop_on_resize: bool) -> Option<RunOutcome> {
@@ -102,10 +124,25 @@ pub fn dump_effect(
         }
     }
     out.flush().ok();
-    eprintln!("frames={count}");
+    crate::errln!("frames={count}");
     Ok(count)
 }
 
 fn io_err(e: std::io::Error) -> EngineError {
     EngineError::Other(format!("io error: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Error, ErrorKind};
+
+    #[test]
+    fn a_lost_output_stream_is_not_an_error() {
+        assert!(output_closed(&Error::from_raw_os_error(5)));
+        assert!(output_closed(&Error::from(ErrorKind::BrokenPipe)));
+        // A full disk or a revoked device still deserves a report.
+        assert!(!output_closed(&Error::from_raw_os_error(28)));
+        assert!(!output_closed(&Error::from(ErrorKind::PermissionDenied)));
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,38 @@ pub mod utils;
 
 use std::sync::atomic::{AtomicBool, Ordering};
 
+/// `println!` and `eprintln!` panic when their write fails, and a release
+/// build aborts on panic — so on a terminal that has just gone away, reporting
+/// the loss is what dumps the core, not the loss itself:
+///
+/// ```text
+/// thread 'main' panicked at library/std/src/io/stdio.rs:1166:9:
+/// failed printing to stderr: Input/output error (os error 5)
+/// ```
+///
+/// Nothing ttfx says is worth dying over, so messages go out through these two
+/// and a failed write is dropped (basecamp/omarchy#6762).
+#[macro_export]
+macro_rules! outln {
+    ($($arg:tt)*) => {{
+        let _ = ::std::io::Write::write_fmt(
+            &mut ::std::io::stdout(),
+            format_args!("{}\n", format_args!($($arg)*)),
+        );
+    }};
+}
+
+/// [`outln!`] for stderr.
+#[macro_export]
+macro_rules! errln {
+    ($($arg:tt)*) => {{
+        let _ = ::std::io::Write::write_fmt(
+            &mut ::std::io::stderr(),
+            format_args!("{}\n", format_args!($($arg)*)),
+        );
+    }};
+}
+
 static INTERRUPTED: AtomicBool = AtomicBool::new(false);
 static TERMINATED: AtomicBool = AtomicBool::new(false);
 static TERMINAL_RESIZED: AtomicBool = AtomicBool::new(false);

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ fn get_piped_input() -> String {
     match String::from_utf8(buf) {
         Ok(s) => s,
         Err(e) => {
-            println!("Error decoding input: {e}");
+            ttfx::outln!("Error decoding input: {e}");
             std::process::exit(1);
         }
     }
@@ -59,12 +59,12 @@ fn main() -> ExitCode {
                 Ok(s) => s,
                 Err(e) => {
                     // upstream prints runtime file errors to STDOUT and exits 1
-                    println!("Error reading input file: {e}");
+                    ttfx::outln!("Error reading input file: {e}");
                     return ExitCode::from(1);
                 }
             },
             Err(e) => {
-                println!("Error reading input file: {e}");
+                ttfx::outln!("Error reading input file: {e}");
                 return ExitCode::from(1);
             }
         },
@@ -72,7 +72,7 @@ fn main() -> ExitCode {
     };
 
     if input_data.trim().is_empty() {
-        println!("NO INPUT.");
+        ttfx::outln!("NO INPUT.");
         return ExitCode::from(1);
     }
 
@@ -99,14 +99,14 @@ fn main() -> ExitCode {
         }
         names.retain(|n| !cli.exclude_effects.contains(n));
         if names.is_empty() {
-            eprintln!("Error: No effects available after filtering.");
+            ttfx::errln!("Error: No effects available after filtering.");
             return ExitCode::from(1);
         }
         let name = names[rng.choice_index(names.len())].clone();
         chosen_effect = match clap::Parser::try_parse_from::<_, &str>(["ttfx", &name]) {
             Ok(cli::Cli { effect: Some(effect), .. }) => effect,
             _ => {
-                eprintln!("Error: failed to build effect '{name}'.");
+                ttfx::errln!("Error: failed to build effect '{name}'.");
                 return ExitCode::from(1);
             }
         };
@@ -115,7 +115,7 @@ fn main() -> ExitCode {
         match &cli.effect {
             Some(effect) => effect,
             None => {
-                eprintln!("Error: No effect specified.");
+                ttfx::errln!("Error: No effect specified.");
                 return ExitCode::from(1);
             }
         }
@@ -151,11 +151,11 @@ fn main() -> ExitCode {
         ) {
             Ok(ctx) => ctx,
             Err(engine::error::EngineError::UnsupportedAnsiSequence(seq)) => {
-                eprintln!("Error: Unsupported ANSI sequence in input data: {seq:?}");
+                ttfx::errln!("Error: Unsupported ANSI sequence in input data: {seq:?}");
                 return ExitCode::from(1);
             }
             Err(e) => {
-                eprintln!("Error: {e}");
+                ttfx::errln!("Error: {e}");
                 return ExitCode::from(1);
             }
         };
@@ -197,7 +197,7 @@ fn main() -> ExitCode {
             }
         }
         Err(e) => {
-            eprintln!("Error: {e}");
+            ttfx::errln!("Error: {e}");
             ExitCode::from(1)
         }
     }
@@ -210,11 +210,11 @@ fn m0_dump(input_data: &str, cli: &cli::Cli) -> ExitCode {
     let mut terminal = match Terminal::new(input_data, config) {
         Ok(t) => t,
         Err(engine::error::EngineError::UnsupportedAnsiSequence(seq)) => {
-            eprintln!("Error: Unsupported ANSI sequence in input data: {seq:?}");
+            ttfx::errln!("Error: Unsupported ANSI sequence in input data: {seq:?}");
             return ExitCode::from(1);
         }
         Err(e) => {
-            eprintln!("Error: {e}");
+            ttfx::errln!("Error: {e}");
             return ExitCode::from(1);
         }
     };

--- a/tools/tests/terminal_close_behavior.py
+++ b/tools/tests/terminal_close_behavior.py
@@ -1,0 +1,143 @@
+"""Losing the terminal mid-animation, driven on a real pty.
+
+When the terminal an animation is drawing on goes away — the screensaver's
+window killed at lock, an emulator exiting — every write from here on fails
+with EIO. That is the display ending, not a failure of the run: ttfx must stop
+quietly, say nothing about it, and above all not abort. Reporting it was the
+whole bug (basecamp/omarchy#6762): `eprintln!` panics when stderr is the dead
+terminal too, and a release build aborts on panic, so every idle lock left a
+core dump behind.
+
+Only a real pty shows this, so this spawns the built binary with its stdout on
+one and closes the master out from under it.
+
+Usage: terminal_close_behavior.py [path-to-ttfx]
+"""
+
+from __future__ import annotations
+
+import fcntl
+import os
+import select
+import signal
+import struct
+import sys
+import termios
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+BIN = sys.argv[1] if len(sys.argv) > 1 else str(ROOT / "target/release/ttfx")
+HIDE = b"\x1b[?25l"
+# Long enough that the terminal always closes mid-animation.
+ARGS = ["--frame-rate", "30", "colorshift", "--cycles", "100"]
+
+
+def spawn(stderr_pipe: bool):
+    """Fork with stdout on a pty; stderr optionally on a pipe we can read.
+
+    Deliberately no setsid: with the pty as a controlling terminal the kernel
+    also sends SIGHUP when the master closes, and the race between that and
+    the failing write would decide which path the child took. Without one,
+    only the write error is left — the path under test.
+    """
+    sin_r, sin_w = os.pipe()
+    err_r, err_w = os.pipe() if stderr_pipe else (None, None)
+    master, slave = os.openpty()
+    pid = os.fork()
+    if pid == 0:
+        os.close(master)
+        os.close(sin_w)
+        os.dup2(sin_r, 0)
+        os.dup2(slave, 1)
+        os.dup2(err_w if stderr_pipe else slave, 2)
+        os.close(slave)
+        # COLUMNS/LINES would win over the tty we just sized.
+        env = {k: v for k, v in os.environ.items() if k not in ("COLUMNS", "LINES")}
+        os.execve(BIN, [BIN] + ARGS, env)
+        os._exit(127)
+    os.close(slave)
+    os.close(sin_r)
+    if stderr_pipe:
+        os.close(err_w)
+    fcntl.ioctl(master, termios.TIOCSWINSZ, struct.pack("HHHH", 24, 80, 0, 0))
+    os.write(sin_w, b"hello\n")
+    os.close(sin_w)
+    return pid, master, err_r
+
+
+def drain(source: int, until: bytes | None = None) -> bytes:
+    """Read until `until` shows up, or with no needle until the source ends."""
+    captured = bytearray()
+    deadline = time.monotonic() + 2.0
+    while time.monotonic() < deadline:
+        if until is not None and until in captured:
+            break
+        if not select.select([source], [], [], 0.02)[0]:
+            continue
+        try:
+            chunk = os.read(source, 65536)
+        except OSError:  # the pty master reports EIO once the child is gone
+            break
+        if not chunk:
+            break
+        captured.extend(chunk)
+    return bytes(captured)
+
+
+def reap(pid: int) -> int | None:
+    """Wait out the exit; None means it is still running and had to be killed."""
+    deadline = time.monotonic() + 2.0
+    while time.monotonic() < deadline:
+        done, status = os.waitpid(pid, os.WNOHANG)
+        if done:
+            return status
+        time.sleep(0.01)
+    os.kill(pid, signal.SIGKILL)
+    os.waitpid(pid, 0)
+    return None
+
+
+def run(stderr_pipe: bool):
+    pid, master, err_r = spawn(stderr_pipe)
+    drain(master, until=HIDE)
+    os.close(master)  # the terminal is gone; the next frame hits EIO
+    status = reap(pid)
+    stderr = drain(err_r) if stderr_pipe else b""
+    if stderr_pipe:
+        os.close(err_r)
+    return status, stderr
+
+
+def exited_quietly(status: int | None) -> bool:
+    return status is not None and os.WIFEXITED(status) and os.WEXITSTATUS(status) == 0
+
+
+def aborted(status: int | None) -> bool:
+    return status is not None and os.WIFSIGNALED(status) and os.WTERMSIG(status) == signal.SIGABRT
+
+
+def main() -> int:
+    if sys.platform != "linux":
+        # A pty slave whose master is closed only reliably reports EIO here.
+        print("terminal close behavior: skipped (linux only)")
+        return 0
+    pipe_status, pipe_stderr = run(True)
+    tty_status, _ = run(False)
+    checks = [
+        ("a closed terminal ends the run", exited_quietly(pipe_status)),
+        ("nothing is reported about it", pipe_stderr == b""),
+        ("no abort with stderr on the dead terminal", not aborted(tty_status)),
+        ("that run ends too", tty_status is not None),
+    ]
+    for label, passed in checks:
+        print(f"  {'ok  ' if passed else 'FAIL'} {label}")
+    failures = sum(not passed for _, passed in checks)
+    if failures and pipe_stderr:
+        print(f"\nstderr: {pipe_stderr.decode(errors='replace').strip()}")
+    print(f"\nterminal close behavior: {'all checks passed' if not failures else f'{failures} failed'}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Fixes the ttfx side of [basecamp/omarchy#6762](https://github.com/basecamp/omarchy/issues/6762), which [still reproduces](https://github.com/basecamp/omarchy/issues/6762#issuecomment-5307592020) on `ttfx 0.3.1-1`: every idle lock leaves a ttfx core dump behind.

## What happens

The lock kills ttfx, the screensaver's `while true` loop immediately starts a new one, and the terminal is killed a moment later — so the fresh renderer is drawing into a pty whose master is already gone. Its next write fails with EIO, that error is reported with `eprintln!`, and stderr is the same dead terminal, so the report panics:

```
thread 'main' panicked at library/std/src/io/stdio.rs:1166:9:
failed printing to stderr: Input/output error (os error 5)
```

Release builds are `panic = "abort"`, so the panic is a SIGABRT and a ~1 MB core. No amount of kill-ordering in Omarchy closes this: the respawn can always land inside the lock window.

## The fix

Two commits, each standing on its own:

1. **Printing never kills us.** `outln!`/`errln!` drop a failed write instead of panicking. Nothing ttfx says is worth dying over.
2. **A lost terminal ends the run.** EIO/EPIPE from the output tty is the display ending, not a failure of the run — the pass stops quietly, exit 0, with no teardown attempted on a stream that has nothing left to restore. Scoped to tty output: a write that fails to a redirected file is a real failure and still reports.

## Verification

`tools/tests/terminal_close_behavior.py` is a new pty suite (wired into `bin/test`) that starts an animation, closes the pty master under it, and asserts a quiet exit and no abort. It fails on unmodified `master` with exactly the reported error, and passes here. Running the old binary through it produced a `SIGABRT` core in `coredumpctl`; three runs of the new one produced none.

The rest of `bin/test` is green: 354 effect-parity cases, 41 tty byte-stream parity cases, CLI corpus, SIGTERM and resize suites. (`easing_goldens` fails on my local glibc, one ULP on two samples, identically on unmodified `master` — it is pinned to the CI runner.)

Users get this once ttfx is released and the package rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
