### PR TITLE
windows support for ttfx

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,8 @@
 tools/parity/cases.txt merge=union
 docs/ordering-inventory.md merge=union
+# Git for Windows checks out with CRLF by default, which breaks `sh` scripts
+# (and therefore the Windows CI job) before they test anything.
+*.sh text eol=lf
+bin/test text eol=lf
+bin/build text eol=lf
+bin/release text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,11 @@ jobs:
   test-windows:
     name: Tests (Windows)
     # bin/test is the single entry point like the other jobs: it skips the
-    # Linux-pinned parity and pty suites off Linux, so what runs here proves
-    # the port builds, unit tests green, and the CLI works on Windows with
-    # zero new dependencies. setup-python stays because bin/test requires a
-    # python3 binary to be present before it runs anything.
+    # Linux-pinned parity suites off Linux and the POSIX pty suites on
+    # Windows, so what runs here proves the port builds, unit tests green,
+    # and the CLI works on Windows with zero new dependencies. setup-python
+    # stays because bin/test requires a python3 binary to be present before
+    # it runs anything.
     runs-on: windows-latest
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,27 @@ jobs:
           name: ttfx-aarch64-apple-darwin
           path: target/release/ttfx
 
+  test-windows:
+    name: Tests (Windows)
+    # Same contract as macOS: bin/test skips the Linux-pinned parity and pty
+    # suites off Linux, so this proves the port builds, unit tests green, and
+    # the CLI works on Windows with zero new dependencies.
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: cargo test --release
+      - run: cargo build --release
+      - run: ./tools/tests/cli_corpus.sh
+        shell: bash
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ttfx-x86_64-pc-windows-msvc
+          path: target/release/ttfx.exe
+
   release-binary:
     name: Static musl binary
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,20 +39,22 @@ jobs:
 
   test-windows:
     name: Tests (Windows)
-    # Same contract as macOS: bin/test skips the Linux-pinned parity and pty
-    # suites off Linux, so this proves the port builds, unit tests green, and
-    # the CLI works on Windows with zero new dependencies.
+    # bin/test is the single entry point like the other jobs: it skips the
+    # Linux-pinned parity and pty suites off Linux, so what runs here proves
+    # the port builds, unit tests green, and the CLI works on Windows with
+    # zero new dependencies. setup-python stays because bin/test requires a
+    # python3 binary to be present before it runs anything.
     runs-on: windows-latest
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: cargo test --release
-      - run: cargo build --release
-      - run: ./tools/tests/cli_corpus.sh
-        shell: bash
+      - run: ./bin/test
       - uses: actions/upload-artifact@v4
         with:
           name: ttfx-x86_64-pc-windows-msvc

--- a/README.md
+++ b/README.md
@@ -143,8 +143,8 @@ Upstream is not vendored here — the harness fetches it, because it's their cod
 
 ## Scope
 
-Linux and macOS. Built for [Omarchy](https://omarchy.org) originally; nothing targets a
-specific libc, and CI runs the tests and CLI corpus on both platforms. The byte-exact
+Linux, macOS, and Windows. Built for [Omarchy](https://omarchy.org) originally; nothing targets a
+specific libc, and CI runs the tests and CLI corpus on all three platforms. The byte-exact
 parity suites stay pinned to Linux/glibc — Apple's libm rounds a few transcendentals a
 last-ulp differently, which quantization hides in real frames but a bit-exact comparison
 would surface.

--- a/bin/test
+++ b/bin/test
@@ -20,9 +20,11 @@ cargo test --release
 
 # The pty suites below are Unix-only: they import fcntl/pty/termios at module
 # scope and drive real POSIX signals, so they cannot even start on Windows
-# (Git for Windows reports MINGW64_NT/MSYS/CYGWIN here, never Linux).
+# (Git for Windows reports MINGW64_NT/MSYS/CYGWIN here). Skipping is by
+# Windows rather than by Linux so macOS keeps running them, as it always has.
 case "$(uname -s)" in
-Linux)
+MINGW*|MSYS*|CYGWIN*) ;;
+*)
   python3 tools/tests/sigterm_behavior.py
   python3 tools/tests/terminal_close_behavior.py
   ;;

--- a/bin/test
+++ b/bin/test
@@ -17,8 +17,16 @@ cd "$ROOT"
 cargo test --release
 "$ROOT/bin/build"
 ./tools/tests/cli_corpus.sh
-python3 tools/tests/sigterm_behavior.py
-python3 tools/tests/terminal_close_behavior.py
+
+# The pty suites below are Unix-only: they import fcntl/pty/termios at module
+# scope and drive real POSIX signals, so they cannot even start on Windows
+# (Git for Windows reports MINGW64_NT/MSYS/CYGWIN here, never Linux).
+case "$(uname -s)" in
+Linux)
+  python3 tools/tests/sigterm_behavior.py
+  python3 tools/tests/terminal_close_behavior.py
+  ;;
+esac
 
 # Bit-exact parity is pinned to Linux/glibc (plan.md §5.20) — elsewhere the
 # reference was never promised to match. The resize suite goes with it: its

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,12 +71,15 @@ pub struct ConsoleModeGuard {
 
 impl ConsoleModeGuard {
     pub fn enable() -> Self {
-        #[cfg(windows)]
-        windows::enable_virtual_terminal();
         // `panic = "abort"` in release skips `Drop`, but panic hooks still
-        // run first — so the saved mode goes back even on that path.
+        // run first — so the saved mode goes back even on that path. Arming
+        // the hook first leaves no window where the mode is changed and only
+        // the default hook is installed; the resize thread is already running
+        // by here, so that window is reachable rather than theoretical.
         #[cfg(windows)]
         windows::install_panic_hook();
+        #[cfg(windows)]
+        windows::enable_virtual_terminal();
         ConsoleModeGuard { _priv: () }
     }
 }
@@ -259,7 +262,7 @@ mod windows {
     }
 
     pub(super) fn restore_console_mode() {
-        if !OUTPUT_MODE_SAVED.swap(false, Ordering::SeqCst) {
+        if !OUTPUT_MODE_SAVED.load(Ordering::SeqCst) {
             return;
         }
         let saved = SAVED_OUTPUT_MODE.load(Ordering::SeqCst);
@@ -271,6 +274,11 @@ mod windows {
             }
             let _ = SetConsoleMode(out, saved);
         }
+        // Cleared last, so a caller that reads false knows the mode is already
+        // back. Clearing on entry let a second caller return early and exit the
+        // process while the first had not yet reached SetConsoleMode. Restoring
+        // twice writes the same saved mode, so the race this leaves is harmless.
+        OUTPUT_MODE_SAVED.store(false, Ordering::SeqCst);
     }
 
     /// Ctrl-C / Ctrl-Break sets INTERRUPTED so the run loop tears down the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,68 +41,12 @@ static INTERRUPTED: AtomicBool = AtomicBool::new(false);
 static TERMINATED: AtomicBool = AtomicBool::new(false);
 static TERMINAL_RESIZED: AtomicBool = AtomicBool::new(false);
 
-/// SIGINT is recorded and checked from the run loop so teardown (cursor
-/// restore) happens through normal control flow — Drop alone would not run on
-/// a raw signal exit (plan.md §8).
-pub fn install_sigint_handler() {
-    // SAFETY: signal(2) with a signal-safe handler that only stores a flag.
-    unsafe {
-        libc_signal(SIGINT, handle_sigint as *const () as usize);
-    }
-}
-
-extern "C" fn handle_sigint(_: i32) {
-    INTERRUPTED.store(true, Ordering::SeqCst);
-}
-
 pub fn interrupted() -> bool {
     INTERRUPTED.load(Ordering::SeqCst)
 }
 
-/// SIGTERM is recorded like SIGINT so a supervisor killing an animation gets
-/// the normal teardown instead of a hidden cursor. `die_from_sigterm` then
-/// finishes the job the handler deferred.
-pub fn install_sigterm_handler() {
-    // SAFETY: signal(2) with a signal-safe handler that only stores a flag.
-    unsafe {
-        libc_signal(SIGTERM, handle_sigterm as *const () as usize);
-    }
-}
-
-extern "C" fn handle_sigterm(_: i32) {
-    TERMINATED.store(true, Ordering::SeqCst);
-}
-
 pub fn terminated() -> bool {
     TERMINATED.load(Ordering::SeqCst)
-}
-
-/// Finish the SIGTERM we deferred: the cursor is back, so hand the signal to
-/// the default action and die from it. A supervisor then sees a terminated
-/// child, exactly as it would from the redirected run that never installs a
-/// handler at all. SIGINT does not go through here — upstream exits 1 on
-/// KeyboardInterrupt and parity outranks the convention (plan.md §8).
-pub fn die_from_sigterm() -> ! {
-    // SAFETY: restoring the default action and re-raising is the documented
-    // way to exit with a signal's status; raise(2) here does not return.
-    unsafe {
-        libc_signal(SIGTERM, SIG_DFL);
-        libc_raise(SIGTERM);
-    }
-    unreachable!("SIGTERM with the default action terminates the process");
-}
-
-/// Record terminal resizes so the CLI can rebuild effects whose canvas and
-/// character positions were derived from the previous dimensions.
-pub fn install_sigwinch_handler() {
-    // SAFETY: signal(2) with a signal-safe handler that only stores a flag.
-    unsafe {
-        libc_signal(SIGWINCH, handle_sigwinch as *const () as usize);
-    }
-}
-
-extern "C" fn handle_sigwinch(_: i32) {
-    TERMINAL_RESIZED.store(true, Ordering::SeqCst);
 }
 
 /// Consume a pending terminal resize notification.
@@ -110,36 +54,272 @@ pub fn take_terminal_resize() -> bool {
     TERMINAL_RESIZED.swap(false, Ordering::SeqCst)
 }
 
-/// Restore default SIGPIPE so `ttfx ... | head` dies quietly like any Unix
-/// tool instead of panicking on a broken pipe (Rust ignores SIGPIPE by default).
-pub fn restore_sigpipe() {
-    unsafe {
-        libc_signal(SIGPIPE, SIG_DFL);
+/// Test seam: raise the same flag the Unix signal and the Windows console
+/// watcher raise, without touching OS handlers.
+pub fn notify_terminal_resize() {
+    TERMINAL_RESIZED.store(true, Ordering::SeqCst);
+}
+
+/// Enable ANSI escape processing. No-op on Unix; on Windows turns on
+/// VIRTUAL_TERMINAL_PROCESSING for stdout (best effort: a redirected handle
+/// or an old console just keeps working without colors).
+pub fn enable_ansi() {
+    #[cfg(windows)]
+    windows::enable_virtual_terminal();
+}
+
+#[cfg(unix)]
+pub use unix::{
+    die_from_sigterm, install_sigint_handler, install_sigterm_handler, install_sigwinch_handler,
+    restore_sigpipe,
+};
+
+#[cfg(windows)]
+pub use windows::{
+    die_from_sigterm, install_sigint_handler, install_sigterm_handler, install_sigwinch_handler,
+    restore_sigpipe,
+};
+
+#[cfg(unix)]
+mod unix {
+    use super::{INTERRUPTED, TERMINATED, TERMINAL_RESIZED};
+    use std::sync::atomic::Ordering;
+
+    /// SIGINT is recorded and checked from the run loop so teardown (cursor
+    /// restore) happens through normal control flow — Drop alone would not run on
+    /// a raw signal exit (plan.md §8).
+    pub fn install_sigint_handler() {
+        // SAFETY: signal(2) with a signal-safe handler that only stores a flag.
+        unsafe {
+            libc_signal(SIGINT, handle_sigint as *const () as usize);
+        }
+    }
+
+    extern "C" fn handle_sigint(_: i32) {
+        INTERRUPTED.store(true, Ordering::SeqCst);
+    }
+
+    /// SIGTERM is recorded like SIGINT so a supervisor killing an animation gets
+    /// the normal teardown instead of a hidden cursor. `die_from_sigterm` then
+    /// finishes the job the handler deferred.
+    pub fn install_sigterm_handler() {
+        // SAFETY: signal(2) with a signal-safe handler that only stores a flag.
+        unsafe {
+            libc_signal(SIGTERM, handle_sigterm as *const () as usize);
+        }
+    }
+
+    extern "C" fn handle_sigterm(_: i32) {
+        TERMINATED.store(true, Ordering::SeqCst);
+    }
+
+    /// Finish the SIGTERM we deferred: the cursor is back, so hand the signal to
+    /// the default action and die from it. A supervisor then sees a terminated
+    /// child, exactly as it would from the redirected run that never installs a
+    /// handler at all. SIGINT does not go through here — upstream exits 1 on
+    /// KeyboardInterrupt and parity outranks the convention (plan.md §8).
+    pub fn die_from_sigterm() -> ! {
+        // SAFETY: restoring the default action and re-raising is the documented
+        // way to exit with a signal's status; raise(2) here does not return.
+        unsafe {
+            libc_signal(SIGTERM, SIG_DFL);
+            libc_raise(SIGTERM);
+        }
+        unreachable!("SIGTERM with the default action terminates the process");
+    }
+
+    /// Record terminal resizes so the CLI can rebuild effects whose canvas and
+    /// character positions were derived from the previous dimensions.
+    pub fn install_sigwinch_handler() {
+        // SAFETY: signal(2) with a signal-safe handler that only stores a flag.
+        unsafe {
+            libc_signal(SIGWINCH, handle_sigwinch as *const () as usize);
+        }
+    }
+
+    extern "C" fn handle_sigwinch(_: i32) {
+        TERMINAL_RESIZED.store(true, Ordering::SeqCst);
+    }
+
+    /// Restore default SIGPIPE so `ttfx ... | head` dies quietly like any Unix
+    /// tool instead of panicking on a broken pipe (Rust ignores SIGPIPE by default).
+    pub fn restore_sigpipe() {
+        unsafe {
+            libc_signal(SIGPIPE, SIG_DFL);
+        }
+    }
+
+    const SIGINT: i32 = 2;
+    const SIGTERM: i32 = 15;
+    const SIGPIPE: i32 = 13;
+    /// 28 on Linux and on the BSDs, macOS included.
+    const SIGWINCH: i32 = 28;
+    const SIG_DFL: usize = 0;
+
+    unsafe fn libc_signal(signum: i32, handler: usize) {
+        unsafe extern "C" {
+            fn signal(signum: i32, handler: usize) -> usize;
+        }
+        unsafe {
+            signal(signum, handler);
+        }
+    }
+
+    unsafe fn libc_raise(signum: i32) {
+        unsafe extern "C" {
+            fn raise(signum: i32) -> i32;
+        }
+        unsafe {
+            raise(signum);
+        }
     }
 }
 
-const SIGINT: i32 = 2;
-const SIGTERM: i32 = 15;
-const SIGPIPE: i32 = 13;
-/// 28 on Linux and on the BSDs, macOS included.
-const SIGWINCH: i32 = 28;
-const SIG_DFL: usize = 0;
+/// Windows platform: no new crates, raw kernel32 via `extern "system"`.
+/// Ctrl-C and resize feed the same Atomics the Unix signals feed, so the run
+/// loop, teardown, and `resize_settled()` debounce stay shared.
+#[cfg(windows)]
+mod windows {
+    use super::{INTERRUPTED, TERMINAL_RESIZED};
+    use std::sync::atomic::Ordering;
 
-unsafe fn libc_signal(signum: i32, handler: usize) {
-    unsafe extern "C" {
-        fn signal(signum: i32, handler: usize) -> usize;
-    }
-    unsafe {
-        signal(signum, handler);
-    }
-}
+    type Handle = isize;
+    type Dword = u32;
+    type Bool = i32;
 
-unsafe fn libc_raise(signum: i32) {
-    unsafe extern "C" {
-        fn raise(signum: i32) -> i32;
+    const STD_OUTPUT_HANDLE: Dword = 0xFFFF_FFF5;
+    const ENABLE_VIRTUAL_TERMINAL_PROCESSING: Dword = 0x0004;
+    const WINDOW_BUFFER_SIZE_EVENT: u16 = 0x0004;
+    const CTRL_C_EVENT: Dword = 0;
+    const CTRL_BREAK_EVENT: Dword = 1;
+
+    unsafe extern "system" {
+        fn GetStdHandle(nStdHandle: Dword) -> Handle;
+        fn GetConsoleMode(hConsoleHandle: Handle, lpMode: *mut Dword) -> Bool;
+        fn SetConsoleMode(hConsoleHandle: Handle, dwMode: Dword) -> Bool;
+        fn SetConsoleCtrlHandler(handler: Option<unsafe extern "system" fn(Dword) -> Bool>, add: Bool)
+        -> Bool;
+        fn CreateFileW(
+            lpFileName: *const u16,
+            dwDesiredAccess: Dword,
+            dwShareMode: Dword,
+            lpSecurityAttributes: *const u8,
+            dwCreationDisposition: Dword,
+            dwFlagsAndAttributes: Dword,
+            hTemplateFile: Handle,
+        ) -> Handle;
+        fn ReadConsoleInputW(
+            hConsoleInput: Handle,
+            lpBuffer: *mut InputRecord,
+            nLength: Dword,
+            lpNumberOfEventsRead: *mut Dword,
+        ) -> Bool;
+        fn CloseHandle(hObject: Handle) -> Bool;
     }
-    unsafe {
-        raise(signum);
+
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    struct InputRecord {
+        event_type: u16,
+        reserved: u16,
+        payload: [u8; 16],
+    }
+
+    pub(super) fn enable_virtual_terminal() {
+        // SAFETY: plain kernel32 queries on the output handle; failure
+        // (redirected handle, old console) just means colors stay off.
+        unsafe {
+            let out = GetStdHandle(STD_OUTPUT_HANDLE);
+            if out == 0 || out == -1 {
+                return;
+            }
+            let mut mode: Dword = 0;
+            if GetConsoleMode(out, &mut mode) == 0 {
+                return;
+            }
+            let _ = SetConsoleMode(out, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+        }
+    }
+
+    /// Ctrl-C / Ctrl-Break sets INTERRUPTED so the run loop tears down the
+    /// cursor through normal control flow, exactly like SIGINT on Unix.
+    pub fn install_sigint_handler() {
+        // SAFETY: handler only stores an atomic flag.
+        unsafe {
+            SetConsoleCtrlHandler(Some(handle_ctrl), 1);
+        }
+    }
+
+    unsafe extern "system" fn handle_ctrl(ctrl_type: Dword) -> Bool {
+        if ctrl_type == CTRL_C_EVENT || ctrl_type == CTRL_BREAK_EVENT {
+            INTERRUPTED.store(true, Ordering::SeqCst);
+            1
+        } else {
+            0
+        }
+    }
+
+    /// No SIGTERM on Windows; kept so `main.rs` stays platform-free.
+    pub fn install_sigterm_handler() {}
+
+    /// Windows never delivers SIGTERM to console apps; exit 1 after teardown.
+    pub fn die_from_sigterm() -> ! {
+        std::process::exit(1);
+    }
+
+    /// No SIGPIPE on Windows.
+    pub fn restore_sigpipe() {}
+
+    /// Watch `CONIN$` for WINDOW_BUFFER_SIZE_EVENTs on a parked thread and set
+    /// the same TERMINAL_RESIZED flag SIGWINCH sets on Unix. `CONIN$` is opened
+    /// explicitly so this works even when stdin itself is a pipe
+    /// (`echo hi | ttfx`), which is the normal case.
+    pub fn install_sigwinch_handler() {
+        std::thread::spawn(|| {
+            // SAFETY: minimal kernel32 console input pump; any failure ends
+            // the thread quietly — resize-restart just stays off.
+            unsafe { watch_for_resize() };
+        });
+    }
+
+    unsafe fn watch_for_resize() {
+        const GENERIC_READ: Dword = 0x8000_0000;
+        const GENERIC_WRITE: Dword = 0x4000_0000;
+        const FILE_SHARE_READ: Dword = 1;
+        const FILE_SHARE_WRITE: Dword = 2;
+        const OPEN_EXISTING: Dword = 3;
+
+        // "CONIN$" as UTF-16 + NUL.
+        let name: [u16; 7] = [0x43, 0x4F, 0x4E, 0x49, 0x4E, 0x24, 0];
+        let conin = CreateFileW(
+            name.as_ptr(),
+            GENERIC_READ | GENERIC_WRITE,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            std::ptr::null(),
+            OPEN_EXISTING,
+            0,
+            0,
+        );
+        if conin == 0 || conin == -1 {
+            return;
+        }
+        let mut record = InputRecord { event_type: 0, reserved: 0, payload: [0; 16] };
+        loop {
+            let mut read: Dword = 0;
+            let ok = ReadConsoleInputW(conin, &mut record, 1, &mut read);
+            if ok == 0 || read == 0 {
+                break;
+            }
+            if record.event_type == WINDOW_BUFFER_SIZE_EVENT {
+                TERMINAL_RESIZED.store(true, Ordering::SeqCst);
+            }
+        }
+        CloseHandle(conin);
+    }
+
+    #[allow(dead_code)]
+    pub(super) fn set_resized_for_test() {
+        TERMINAL_RESIZED.store(true, Ordering::SeqCst);
     }
 }
 
@@ -150,7 +330,7 @@ mod tests {
     #[test]
     fn terminal_resize_notifications_are_consumed() {
         take_terminal_resize();
-        handle_sigwinch(SIGWINCH);
+        notify_terminal_resize();
         assert!(take_terminal_resize());
         assert!(!take_terminal_resize());
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,12 +60,28 @@ pub fn notify_terminal_resize() {
     TERMINAL_RESIZED.store(true, Ordering::SeqCst);
 }
 
-/// Enable ANSI escape processing. No-op on Unix; on Windows turns on
+/// Enable ANSI escape processing for the run, restoring the previous console
+/// mode when dropped. No-op on Unix; on Windows turns on
 /// VIRTUAL_TERMINAL_PROCESSING for stdout (best effort: a redirected handle
-/// or an old console just keeps working without colors).
-pub fn enable_ansi() {
-    #[cfg(windows)]
-    windows::enable_virtual_terminal();
+/// or an old console just keeps working without colors) and puts the saved
+/// mode back so the user's shell is left as it was found.
+pub struct ConsoleModeGuard {
+    _priv: (),
+}
+
+impl ConsoleModeGuard {
+    pub fn enable() -> Self {
+        #[cfg(windows)]
+        windows::enable_virtual_terminal();
+        ConsoleModeGuard { _priv: () }
+    }
+}
+
+impl Drop for ConsoleModeGuard {
+    fn drop(&mut self) {
+        #[cfg(windows)]
+        windows::restore_console_mode();
+    }
 }
 
 #[cfg(unix)]
@@ -181,7 +197,7 @@ mod unix {
 #[cfg(windows)]
 mod windows {
     use super::{INTERRUPTED, TERMINAL_RESIZED};
-    use std::sync::atomic::Ordering;
+    use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
     type Handle = isize;
     type Dword = u32;
@@ -189,9 +205,11 @@ mod windows {
 
     const STD_OUTPUT_HANDLE: Dword = 0xFFFF_FFF5;
     const ENABLE_VIRTUAL_TERMINAL_PROCESSING: Dword = 0x0004;
-    const WINDOW_BUFFER_SIZE_EVENT: u16 = 0x0004;
     const CTRL_C_EVENT: Dword = 0;
     const CTRL_BREAK_EVENT: Dword = 1;
+
+    static SAVED_OUTPUT_MODE: AtomicU32 = AtomicU32::new(0);
+    static OUTPUT_MODE_SAVED: AtomicBool = AtomicBool::new(false);
 
     unsafe extern "system" {
         fn GetStdHandle(nStdHandle: Dword) -> Handle;
@@ -199,35 +217,12 @@ mod windows {
         fn SetConsoleMode(hConsoleHandle: Handle, dwMode: Dword) -> Bool;
         fn SetConsoleCtrlHandler(handler: Option<unsafe extern "system" fn(Dword) -> Bool>, add: Bool)
         -> Bool;
-        fn CreateFileW(
-            lpFileName: *const u16,
-            dwDesiredAccess: Dword,
-            dwShareMode: Dword,
-            lpSecurityAttributes: *const u8,
-            dwCreationDisposition: Dword,
-            dwFlagsAndAttributes: Dword,
-            hTemplateFile: Handle,
-        ) -> Handle;
-        fn ReadConsoleInputW(
-            hConsoleInput: Handle,
-            lpBuffer: *mut InputRecord,
-            nLength: Dword,
-            lpNumberOfEventsRead: *mut Dword,
-        ) -> Bool;
-        fn CloseHandle(hObject: Handle) -> Bool;
-    }
-
-    #[repr(C)]
-    #[derive(Clone, Copy)]
-    struct InputRecord {
-        event_type: u16,
-        reserved: u16,
-        payload: [u8; 16],
     }
 
     pub(super) fn enable_virtual_terminal() {
         // SAFETY: plain kernel32 queries on the output handle; failure
         // (redirected handle, old console) just means colors stay off.
+        // The previous mode is saved so the Drop guard can put it back.
         unsafe {
             let out = GetStdHandle(STD_OUTPUT_HANDLE);
             if out == 0 || out == -1 {
@@ -237,16 +232,37 @@ mod windows {
             if GetConsoleMode(out, &mut mode) == 0 {
                 return;
             }
+            SAVED_OUTPUT_MODE.store(mode, Ordering::SeqCst);
+            OUTPUT_MODE_SAVED.store(true, Ordering::SeqCst);
             let _ = SetConsoleMode(out, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+        }
+    }
+
+    pub(super) fn restore_console_mode() {
+        if !OUTPUT_MODE_SAVED.swap(false, Ordering::SeqCst) {
+            return;
+        }
+        let saved = SAVED_OUTPUT_MODE.load(Ordering::SeqCst);
+        // SAFETY: restoring a mode previously read from the same handle.
+        unsafe {
+            let out = GetStdHandle(STD_OUTPUT_HANDLE);
+            if out == 0 || out == -1 {
+                return;
+            }
+            let _ = SetConsoleMode(out, saved);
         }
     }
 
     /// Ctrl-C / Ctrl-Break sets INTERRUPTED so the run loop tears down the
     /// cursor through normal control flow, exactly like SIGINT on Unix.
     pub fn install_sigint_handler() {
-        // SAFETY: handler only stores an atomic flag.
+        // SAFETY: handler only stores an atomic flag. If registration itself
+        // fails there is nothing safe to do here: Ctrl-C then terminates the
+        // process with default handling, skipping the cursor teardown.
         unsafe {
-            SetConsoleCtrlHandler(Some(handle_ctrl), 1);
+            if SetConsoleCtrlHandler(Some(handle_ctrl), 1) == 0 {
+                crate::errln!("Warning: failed to install console Ctrl handler.");
+            }
         }
     }
 
@@ -263,63 +279,40 @@ mod windows {
     pub fn install_sigterm_handler() {}
 
     /// Windows never delivers SIGTERM to console apps; exit 1 after teardown.
+    /// `exit` skips destructors, so restore the console mode explicitly here
+    /// (the Drop guard cannot run on this path).
     pub fn die_from_sigterm() -> ! {
+        restore_console_mode();
         std::process::exit(1);
     }
 
     /// No SIGPIPE on Windows.
     pub fn restore_sigpipe() {}
 
-    /// Watch `CONIN$` for WINDOW_BUFFER_SIZE_EVENTs on a parked thread and set
-    /// the same TERMINAL_RESIZED flag SIGWINCH sets on Unix. `CONIN$` is opened
-    /// explicitly so this works even when stdin itself is a pipe
-    /// (`echo hi | ttfx`), which is the normal case.
+    /// Poll the terminal size on a parked thread and set the same
+    /// TERMINAL_RESIZED flag SIGWINCH sets on Unix. An event-driven watcher
+    /// would need the console input buffer (`ENABLE_WINDOW_INPUT`) and would
+    /// consume every record it reads — including keystrokes meant for the
+    /// shell. Polling costs one cheap query five times a second, works when
+    /// stdin is a pipe (the normal `echo hi | ttfx` case), and feeds the
+    /// shared `resize_settled()` debounce, so restarts stay as disciplined
+    /// as on Unix.
     pub fn install_sigwinch_handler() {
         std::thread::spawn(|| {
-            // SAFETY: minimal kernel32 console input pump; any failure ends
-            // the thread quietly — resize-restart just stays off.
-            unsafe { watch_for_resize() };
+            let mut last = current_size();
+            loop {
+                std::thread::sleep(std::time::Duration::from_millis(200));
+                let now = current_size();
+                if now != last {
+                    last = now;
+                    TERMINAL_RESIZED.store(true, Ordering::SeqCst);
+                }
+            }
         });
     }
 
-    unsafe fn watch_for_resize() {
-        const GENERIC_READ: Dword = 0x8000_0000;
-        const GENERIC_WRITE: Dword = 0x4000_0000;
-        const FILE_SHARE_READ: Dword = 1;
-        const FILE_SHARE_WRITE: Dword = 2;
-        const OPEN_EXISTING: Dword = 3;
-
-        // "CONIN$" as UTF-16 + NUL.
-        let name: [u16; 7] = [0x43, 0x4F, 0x4E, 0x49, 0x4E, 0x24, 0];
-        let conin = CreateFileW(
-            name.as_ptr(),
-            GENERIC_READ | GENERIC_WRITE,
-            FILE_SHARE_READ | FILE_SHARE_WRITE,
-            std::ptr::null(),
-            OPEN_EXISTING,
-            0,
-            0,
-        );
-        if conin == 0 || conin == -1 {
-            return;
-        }
-        let mut record = InputRecord { event_type: 0, reserved: 0, payload: [0; 16] };
-        loop {
-            let mut read: Dword = 0;
-            let ok = ReadConsoleInputW(conin, &mut record, 1, &mut read);
-            if ok == 0 || read == 0 {
-                break;
-            }
-            if record.event_type == WINDOW_BUFFER_SIZE_EVENT {
-                TERMINAL_RESIZED.store(true, Ordering::SeqCst);
-            }
-        }
-        CloseHandle(conin);
-    }
-
-    #[allow(dead_code)]
-    pub(super) fn set_resized_for_test() {
-        TERMINAL_RESIZED.store(true, Ordering::SeqCst);
+    fn current_size() -> Option<(u16, u16)> {
+        terminal_size::terminal_size().map(|(w, h)| (w.0, h.0))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,10 @@ impl ConsoleModeGuard {
     pub fn enable() -> Self {
         #[cfg(windows)]
         windows::enable_virtual_terminal();
+        // `panic = "abort"` in release skips `Drop`, but panic hooks still
+        // run first — so the saved mode goes back even on that path.
+        #[cfg(windows)]
+        windows::install_panic_hook();
         ConsoleModeGuard { _priv: () }
     }
 }
@@ -236,6 +240,22 @@ mod windows {
             OUTPUT_MODE_SAVED.store(true, Ordering::SeqCst);
             let _ = SetConsoleMode(out, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
         }
+    }
+
+    /// Restore the saved output mode from a panic hook. Hooks run before
+    /// `abort`, unlike `Drop`; chaining keeps any previously installed hook
+    /// (test harness, supervisor) alive. Re-entry safe via the same swap flag
+    /// the `Drop` path uses.
+    pub(super) fn install_panic_hook() {
+        use std::sync::Once;
+        static INSTALL: Once = Once::new();
+        INSTALL.call_once(|| {
+            let previous = std::panic::take_hook();
+            std::panic::set_hook(Box::new(move |info| {
+                restore_console_mode();
+                previous(info);
+            }));
+        });
     }
 
     pub(super) fn restore_console_mode() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,15 +293,19 @@ mod windows {
     /// TERMINAL_RESIZED flag SIGWINCH sets on Unix. An event-driven watcher
     /// would need the console input buffer (`ENABLE_WINDOW_INPUT`) and would
     /// consume every record it reads — including keystrokes meant for the
-    /// shell. Polling costs one cheap query five times a second, works when
-    /// stdin is a pipe (the normal `echo hi | ttfx` case), and feeds the
-    /// shared `resize_settled()` debounce, so restarts stay as disciplined
-    /// as on Unix.
+    /// shell. The sample period stays below `resize_settled()`'s quiet window
+    /// so a sustained drag keeps pushing the timestamp forward and coalesces
+    /// into one restart, exactly like a burst of SIGWINCH on Unix. Works when
+    /// stdin is a pipe (the normal `echo hi | ttfx` case).
+    ///
+    /// The baseline is read on the calling thread: a resize landing between
+    /// the engine's own first sample and the watcher's would otherwise be
+    /// recorded as "no change" and missed until the next resize.
     pub fn install_sigwinch_handler() {
-        std::thread::spawn(|| {
-            let mut last = current_size();
+        let mut last = current_size();
+        std::thread::spawn(move || {
             loop {
-                std::thread::sleep(std::time::Duration::from_millis(200));
+                std::thread::sleep(std::time::Duration::from_millis(30));
                 let now = current_size();
                 if now != last {
                     last = now;

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,13 +76,6 @@ fn main() -> ExitCode {
         return ExitCode::from(1);
     }
 
-    // Console mode is touched only for real runs (never for --help,
-    // --print-completion, parse errors or input errors) and restored by the
-    // guard on every exit path through normal control flow (`exit()` calls
-    // all happen before this point, except the SIGTERM path, which restores
-    // explicitly). No-op off Windows.
-    let _console_mode = ttfx::ConsoleModeGuard::enable();
-
     if cli.m0_dump {
         return m0_dump(&input_data, &cli);
     }
@@ -143,6 +136,14 @@ fn main() -> ExitCode {
         ttfx::install_sigterm_handler();
         ttfx::install_sigwinch_handler();
     }
+
+    // Console mode is touched only for real runs, after the signal handlers
+    // are installed so no Ctrl-C can land on default termination, and
+    // restored by the guard on every exit path through normal control flow
+    // (`exit()` calls all happen before this point, except the SIGTERM path,
+    // which restores explicitly). The hidden `--m0-dump` parity path above
+    // runs without it; its harness is Linux-only. No-op off Windows.
+    let _console_mode = ttfx::ConsoleModeGuard::enable();
 
     let result = loop {
         let clock = if cli.parity_dump || cli.virtual_clock {

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,8 +53,6 @@ fn main() -> ExitCode {
         return ExitCode::SUCCESS;
     }
 
-
-
     let input_data = match &cli.input_file {
         Some(path) => match std::fs::read(path) {
             Ok(bytes) => match String::from_utf8(bytes) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,6 @@ fn forget_engine<E, C>(effect: E, ctx: C) {
 
 fn main() -> ExitCode {
     ttfx::restore_sigpipe();
-    ttfx::enable_ansi();
     let cli = cli::Cli::parse();
 
     // upstream prints the completion script and returns before any input handling
@@ -53,6 +52,8 @@ fn main() -> ExitCode {
         clap_complete::generate(generator, &mut command, "ttfx", &mut std::io::stdout());
         return ExitCode::SUCCESS;
     }
+
+
 
     let input_data = match &cli.input_file {
         Some(path) => match std::fs::read(path) {
@@ -76,6 +77,13 @@ fn main() -> ExitCode {
         ttfx::outln!("NO INPUT.");
         return ExitCode::from(1);
     }
+
+    // Console mode is touched only for real runs (never for --help,
+    // --print-completion, parse errors or input errors) and restored by the
+    // guard on every exit path through normal control flow (`exit()` calls
+    // all happen before this point, except the SIGTERM path, which restores
+    // explicitly). No-op off Windows.
+    let _console_mode = ttfx::ConsoleModeGuard::enable();
 
     if cli.m0_dump {
         return m0_dump(&input_data, &cli);

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,7 @@ fn forget_engine<E, C>(effect: E, ctx: C) {
 
 fn main() -> ExitCode {
     ttfx::restore_sigpipe();
+    ttfx::enable_ansi();
     let cli = cli::Cli::parse();
 
     // upstream prints the completion script and returns before any input handling

--- a/src/utils/rng.rs
+++ b/src/utils/rng.rs
@@ -37,14 +37,14 @@ impl Rng {
         Rng::seeded(u64::from_le_bytes(buf))
     }
 
-    /// Windows entropy without new crates: `ProcessPrng` (bcryptprimitives,
-    /// Win8+) fills the seed directly. Never panics — on failure falls back
-    /// to a time+pid mix, which is plenty for visual effects.
+    /// Windows entropy without new crates: `RtlGenRandom` (`SystemFunction036`
+    /// in advapi32, present in every toolchain) fills the seed directly.
+    /// Never panics — on failure falls back to a time+pid mix, which is
+    /// plenty for visual effects.
     #[cfg(windows)]
     pub fn from_entropy() -> Self {
         Rng::seeded(os_seed().unwrap_or_else(fallback_seed))
     }
-
 
 
     /// Core generator: xoshiro256++ next().

--- a/src/utils/rng.rs
+++ b/src/utils/rng.rs
@@ -25,6 +25,7 @@ impl Rng {
         Rng { s: [next(), next(), next(), next()] }
     }
 
+    #[cfg(unix)]
     pub fn from_entropy() -> Self {
         let mut buf = [0u8; 8];
         // /dev/urandom is always present on the Unix targets we support
@@ -35,6 +36,16 @@ impl Rng {
             .expect("failed to read /dev/urandom");
         Rng::seeded(u64::from_le_bytes(buf))
     }
+
+    /// Windows entropy without new crates: `ProcessPrng` (bcryptprimitives,
+    /// Win8+) fills the seed directly. Never panics — on failure falls back
+    /// to a time+pid mix, which is plenty for visual effects.
+    #[cfg(windows)]
+    pub fn from_entropy() -> Self {
+        Rng::seeded(os_seed().unwrap_or_else(fallback_seed))
+    }
+
+
 
     /// Core generator: xoshiro256++ next().
     fn next_u64(&mut self) -> u64 {
@@ -106,6 +117,32 @@ impl Rng {
     }
 }
 
+/// One OS-backed u64 seed via `RtlGenRandom` (`SystemFunction036` in
+/// advapi32, present in every toolchain). `None` on any failure so the caller
+/// can fall back instead of aborting (release sets `panic = "abort"`).
+#[cfg(windows)]
+fn os_seed() -> Option<u64> {
+    #[link(name = "advapi32")]
+    unsafe extern "system" {
+        fn SystemFunction036(random_buffer: *mut u8, random_buffer_length: u32) -> u8;
+    }
+    let mut buf = [0u8; 8];
+    // SAFETY: fills exactly random_buffer_length bytes on success.
+    let ok = unsafe { SystemFunction036(buf.as_mut_ptr(), buf.len() as u32) };
+    (ok != 0).then(|| u64::from_le_bytes(buf))
+}
+
+/// Last-resort seed: wall-clock nanos mixed with the pid. Uniqueness is all
+/// an unseeded visual run needs.
+#[cfg(windows)]
+fn fallback_seed() -> u64 {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0x9E3779B97F4A7C15);
+    nanos ^ ((std::process::id() as u64).wrapping_mul(0xBF58476D1CE4E5B9))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -117,6 +154,11 @@ mod tests {
         for _ in 0..100 {
             assert_eq!(a.next_u64(), b.next_u64());
         }
+    }
+
+    #[test]
+    fn entropy_does_not_panic() {
+        let _ = Rng::from_entropy();
     }
 
     #[test]

--- a/src/utils/rng.rs
+++ b/src/utils/rng.rs
@@ -46,7 +46,6 @@ impl Rng {
         Rng::seeded(os_seed().unwrap_or_else(fallback_seed))
     }
 
-
     /// Core generator: xoshiro256++ next().
     fn next_u64(&mut self) -> u64 {
         let result = self.s[0].wrapping_add(self.s[3]).rotate_left(23).wrapping_add(self.s[0]);


### PR DESCRIPTION
now ttfx build and run on windows. Linux-only signals and `/dev/urandom` are fenced behind `cfg(unix)`, and a small windows backend using built-in system calls handles colors, Ctrl-C, resize detection, and random seeding through the same shared flags.

updated the CI job to build for windows. 