### PR TITLE
feat: wasm Session, palette, and 4-3-4-3-5 --bands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,19 +160,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
-dependencies = [
- "cfg-if",
- "js-sys",
- "libc",
- "wasi",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,7 +299,6 @@ version = "0.3.2"
 dependencies = [
  "clap",
  "clap_complete",
- "getrandom",
  "js-sys",
  "terminal_size",
  "wasm-bindgen",
@@ -329,12 +315,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
 name = "clap"
 version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,7 +110,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -124,6 +136,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-core"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
+
+[[package]]
+name = "futures-util"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,6 +183,17 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "js-sys"
+version = "0.3.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "libc"
@@ -148,10 +208,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "proc-macro2"
@@ -185,10 +257,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "syn"
+version = "2.0.119"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -217,7 +312,10 @@ version = "0.3.2"
 dependencies = [
  "clap",
  "clap_complete",
+ "getrandom",
+ "js-sys",
  "terminal_size",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -231,6 +329,57 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,10 +5,20 @@ edition = "2021"
 description = "Terminal text effects — a Rust port of terminaltexteffects (TTE)"
 license = "MIT"
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4.6.9"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 terminal_size = "0.4"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2", features = ["js"] }
+js-sys = "0.3"
+wasm-bindgen = "0.2.127"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,85 @@ license = "MIT"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[features]
+default = ["all-effects"]
+all-effects = [
+    "beams",
+    "binarypath",
+    "blackhole",
+    "bouncyballs",
+    "bubbles",
+    "burn",
+    "colorshift",
+    "crumble",
+    "decrypt",
+    "errorcorrect",
+    "expand",
+    "fireworks",
+    "highlight",
+    "laseretch",
+    "matrix",
+    "middleout",
+    "orbittingvolley",
+    "overflow",
+    "pour",
+    "print",
+    "rain",
+    "randomsequence",
+    "rings",
+    "scattered",
+    "slice",
+    "slide",
+    "smoke",
+    "spotlights",
+    "spray",
+    "swarm",
+    "sweep",
+    "synthgrid",
+    "thunderstorm",
+    "unstable",
+    "vhstape",
+    "waves",
+    "wipe",
+]
+beams = []
+binarypath = []
+blackhole = []
+bouncyballs = []
+bubbles = []
+burn = []
+colorshift = []
+crumble = []
+decrypt = []
+errorcorrect = []
+expand = []
+fireworks = []
+highlight = []
+laseretch = []
+matrix = []
+middleout = []
+orbittingvolley = []
+overflow = []
+pour = []
+print = []
+rain = []
+randomsequence = []
+rings = []
+scattered = []
+slice = []
+slide = []
+smoke = []
+spotlights = []
+spray = []
+swarm = []
+sweep = []
+synthgrid = []
+thunderstorm = []
+unstable = []
+vhstape = []
+waves = []
+wipe = []
+
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4.6.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,6 @@ clap_complete = "4.6.9"
 terminal_size = "0.4"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.2", features = ["js"] }
 js-sys = "0.3"
 wasm-bindgen = "0.2.127"
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ ttfx --palette aa0000,00aa00,0000aa,aaaa00,00aaaa --bands decrypt
 colors with commas. Those colors replace each effect's default color arguments;
 color flags you pass on the effect still apply.
 
-`--bands` colors the input word in five vertical field bands: 4, 3, 4, 3, 5
+`--bands` colors the input word in five vertical field bands: 5, 2, 4, 3, 5
 units from the top (crest, hover, lit, mid, dim). The field is 19 units tall,
 one per wordmark bitmap row. Requires `--palette` with five colors in that
 order. The wasm `Session` constructor takes the same palette, background, and

--- a/README.md
+++ b/README.md
@@ -127,11 +127,11 @@ ttfx --palette aa0000,00aa00,0000aa,aaaa00,00aaaa --bands decrypt
 colors with commas. Those colors replace each effect's default color arguments;
 color flags you pass on the effect still apply.
 
-`--bands` colors the input word in five vertical field bands: 4, 1, 4, 3, 5
-units from the top (crest, hover, lit, mid, dim). The field is 17 units tall;
-`t` is 0 at the top of the word and 1 at the bottom. Requires `--palette` with
-five colors in that order. The wasm `Session` constructor takes the same
-palette, background, and `bands` arguments.
+`--bands` colors the input word in five vertical field bands: 4, 3, 4, 3, 5
+units from the top (crest, hover, lit, mid, dim). The field is 19 units tall,
+one per wordmark bitmap row. Requires `--palette` with five colors in that
+order. The wasm `Session` constructor takes the same palette, background, and
+`bands` arguments.
 
 Terminal options (canvas size and anchoring, color handling, frame rate, text wrapping) go
 before the effect name; effect options after it. Option names and defaults match `tte`, so

--- a/README.md
+++ b/README.md
@@ -132,6 +132,16 @@ cargo build --release
 cargo build --release --target x86_64-unknown-linux-musl   # static, ~3.3 MB
 ```
 
+The default build compiles all 37 effects. To ship one, pass its CLI name as a Cargo feature:
+
+```sh
+./bin/build --effect decrypt
+cargo build --release --no-default-features --features decrypt
+cargo build --release --target wasm32-unknown-unknown --lib --no-default-features --features decrypt
+```
+
+`--help`, shell completions, `--random-effect`, and the wasm `effect_catalog()` then list only the effects compiled in. Several can be selected the same way (`--features decrypt,matrix`).
+
 `./bin/test` runs every suite. It needs python3, and the parity half needs a copy of
 upstream, which it clones at the pinned commit on first run:
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,12 @@ ttfx --help                 # all 37 effects and the terminal options
 ttfx <effect> --help        # options for one effect
 ttfx --random-effect        # surprise me (--include-effects / --exclude-effects to filter)
 ttfx --print-completion bash|zsh
+ttfx --palette 7aa2f7,c0caf5,f7768e decrypt
 ```
+
+`--palette` takes hex colors (`#7aa2f7` or `7aa2f7`). Repeat the flag or separate
+colors with commas. Those colors replace each effect's default color arguments;
+color flags you pass on the effect still apply.
 
 Terminal options (canvas size and anchoring, color handling, frame rate, text wrapping) go
 before the effect name; effect options after it. Option names and defaults match `tte`, so

--- a/README.md
+++ b/README.md
@@ -127,11 +127,11 @@ ttfx --palette aa0000,00aa00,0000aa,aaaa00,00aaaa --bands decrypt
 colors with commas. Those colors replace each effect's default color arguments;
 color flags you pass on the effect still apply.
 
-`--bands` colors the input word in five vertical field bands: 3, 1, 3, 2, 4
-units from the top (crest, hover, lit, mid, dim). The drawing is 13 units tall;
-`t` is 0 at the top of the word and 1 at the bottom, so a 19-row wordmark keeps
-those proportions. Requires `--palette` with five colors in that order. The wasm
-`Session` constructor takes the same palette, background, and `bands` arguments.
+`--bands` colors the input word in five vertical field bands: 4, 1, 4, 3, 5
+units from the top (crest, hover, lit, mid, dim). The field is 17 units tall;
+`t` is 0 at the top of the word and 1 at the bottom. Requires `--palette` with
+five colors in that order. The wasm `Session` constructor takes the same
+palette, background, and `bands` arguments.
 
 Terminal options (canvas size and anchoring, color handling, frame rate, text wrapping) go
 before the effect name; effect options after it. Option names and defaults match `tte`, so

--- a/README.md
+++ b/README.md
@@ -120,11 +120,18 @@ ttfx <effect> --help        # options for one effect
 ttfx --random-effect        # surprise me (--include-effects / --exclude-effects to filter)
 ttfx --print-completion bash|zsh
 ttfx --palette 7aa2f7,c0caf5,f7768e decrypt
+ttfx --palette aa0000,00aa00,0000aa,aaaa00,00aaaa --bands decrypt
 ```
 
 `--palette` takes hex colors (`#7aa2f7` or `7aa2f7`). Repeat the flag or separate
 colors with commas. Those colors replace each effect's default color arguments;
 color flags you pass on the effect still apply.
+
+`--bands` colors the input word in five vertical field bands: 3, 1, 3, 2, 4
+units from the top (crest, hover, lit, mid, dim). The drawing is 13 units tall;
+`t` is 0 at the top of the word and 1 at the bottom, so a 19-row wordmark keeps
+those proportions. Requires `--palette` with five colors in that order. The wasm
+`Session` constructor takes the same palette, background, and `bands` arguments.
 
 Terminal options (canvas size and anchoring, color handling, frame rate, text wrapping) go
 before the effect name; effect options after it. Option names and defaults match `tte`, so

--- a/bin/build
+++ b/bin/build
@@ -8,7 +8,45 @@ if ! command -v cargo >/dev/null 2>&1; then
   exit 1
 fi
 
-cd "$ROOT"
-cargo build --release "$@"
+effect=""
+i=1
+n=$#
+while [ "$i" -le "$n" ]; do
+  arg=$1
+  shift
+  case "$arg" in
+  --effect)
+    if [ "$i" -eq "$n" ]; then
+      echo "--effect requires an effect name" >&2
+      exit 1
+    fi
+    effect=$1
+    shift
+    i=$((i + 1))
+    if [ -z "$effect" ]; then
+      echo "--effect requires an effect name" >&2
+      exit 1
+    fi
+    ;;
+  --effect=*)
+    effect=${arg#--effect=}
+    if [ -z "$effect" ]; then
+      echo "--effect requires an effect name" >&2
+      exit 1
+    fi
+    ;;
+  *)
+    set -- "$@" "$arg"
+    ;;
+  esac
+  i=$((i + 1))
+done
 
-echo "Built $ROOT/target/release/ttfx"
+cd "$ROOT"
+if [ -n "$effect" ]; then
+  cargo build --release --no-default-features --features "$effect" "$@"
+  echo "Built $ROOT/target/release/ttfx (effect: $effect)"
+else
+  cargo build --release "$@"
+  echo "Built $ROOT/target/release/ttfx"
+fi

--- a/bin/test
+++ b/bin/test
@@ -15,6 +15,9 @@ done
 cd "$ROOT"
 
 cargo test --release
+# Rebuilds the lib with one effect; does not replace the full binary
+# that bin/build produces for the CLI corpus below.
+cargo test --release --no-default-features --features decrypt --lib
 "$ROOT/bin/build"
 ./tools/tests/cli_corpus.sh
 python3 tools/tests/sigterm_behavior.py

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -123,6 +123,11 @@ pub struct Cli {
     #[arg(long = "palette", value_name = "HEX[,HEX...]", action = clap::ArgAction::Append, value_parser = parse_palette_arg)]
     pub palette_args: Vec<Vec<Color>>,
 
+    /// Color the word in 3-1-3-2-4 field bands using --palette (crest, hover,
+    /// lit, mid, dim from the top). Requires --palette.
+    #[arg(long = "bands", default_value_t = false)]
+    pub bands: bool,
+
     /// Print a shell completion script and exit
     #[arg(long = "print-completion", value_name = "SHELL", value_parser = ["bash", "zsh"])]
     pub print_completion: Option<String>,
@@ -209,6 +214,26 @@ mod tests {
             EffectCommand::Decrypt(config) => config,
             _ => panic!("expected decrypt"),
         }
+    }
+
+    #[test]
+    fn bands_flag_defaults_off() {
+        let cli = Cli::try_parse_from(["ttfx", "--palette", "7aa2f7", "decrypt"]).unwrap();
+        assert!(!cli.bands);
+    }
+
+    #[test]
+    fn bands_flag_is_accepted_with_palette() {
+        let cli = Cli::try_parse_from([
+            "ttfx",
+            "--palette",
+            "aa0000,00aa00,0000aa,aaaa00,00aaaa",
+            "--bands",
+            "decrypt",
+        ])
+        .unwrap();
+        assert!(cli.bands);
+        assert_eq!(cli.palette().unwrap().colors().len(), 5);
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -123,7 +123,7 @@ pub struct Cli {
     #[arg(long = "palette", value_name = "HEX[,HEX...]", action = clap::ArgAction::Append, value_parser = parse_palette_arg)]
     pub palette_args: Vec<Vec<Color>>,
 
-    /// Color the word in 3-1-3-2-4 field bands using --palette (crest, hover,
+    /// Color the word in 4-1-4-3-5 field bands using --palette (crest, hover,
     /// lit, mid, dim from the top). Requires --palette.
     #[arg(long = "bands", default_value_t = false)]
     pub bands: bool,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,6 +7,7 @@ use crate::engine::animation::ExistingColorHandling;
 use crate::engine::canvas::Anchor;
 use crate::engine::terminal::TerminalConfig;
 use crate::utils::graphics::{parse_color, Color};
+use crate::utils::palette::{parse_palette_arg, Palette};
 
 fn parse_positive_int(s: &str) -> Result<i64, String> {
     let v: i64 = s.parse().map_err(|_| format!("invalid int value: '{s}'"))?;
@@ -44,7 +45,9 @@ fn parse_existing_color_handling(s: &str) -> Result<ExistingColorHandling, Strin
         "always" => Ok(ExistingColorHandling::Always),
         "dynamic" => Ok(ExistingColorHandling::Dynamic),
         "ignore" => Ok(ExistingColorHandling::Ignore),
-        _ => Err(format!("invalid choice: '{s}' (choose from 'always', 'dynamic', 'ignore')")),
+        _ => Err(format!(
+            "invalid choice: '{s}' (choose from 'always', 'dynamic', 'ignore')"
+        )),
     }
 }
 
@@ -114,6 +117,12 @@ pub struct Cli {
     #[arg(long = "seed")]
     pub seed: Option<u64>,
 
+    /// Hex colors that replace the effect's default colors. Repeat the flag
+    /// or separate colors with commas. Color flags given on the effect still
+    /// apply.
+    #[arg(long = "palette", value_name = "HEX[,HEX...]", action = clap::ArgAction::Append, value_parser = parse_palette_arg)]
+    pub palette_args: Vec<Vec<Color>>,
+
     /// Print a shell completion script and exit
     #[arg(long = "print-completion", value_name = "SHELL", value_parser = ["bash", "zsh"])]
     pub print_completion: Option<String>,
@@ -173,5 +182,127 @@ impl Cli {
             no_restore_cursor: self.no_restore_cursor,
             terminal_size: None,
         }
+    }
+
+    pub fn palette(&self) -> Option<Palette> {
+        let colors: Vec<Color> = self.palette_args.iter().flatten().copied().collect();
+        Palette::new(colors).ok()
+    }
+}
+
+#[cfg(all(test, feature = "decrypt"))]
+mod tests {
+    use clap::{CommandFactory, FromArgMatches, Parser};
+
+    use super::Cli;
+    use crate::effects::EffectCommand;
+    use crate::utils::graphics::parse_color;
+    use crate::utils::palette::{command_line_arg_ids, Palette};
+
+    fn color(hex: &str) -> crate::utils::graphics::Color {
+        parse_color(hex).expect("test hex")
+    }
+
+    fn decrypt_config(effect: EffectCommand) -> crate::effects::decrypt::DecryptConfig {
+        #[allow(unreachable_patterns)]
+        match effect {
+            EffectCommand::Decrypt(config) => config,
+            _ => panic!("expected decrypt"),
+        }
+    }
+
+    #[test]
+    fn palette_flag_accepts_comma_separated_hex() {
+        let cli = Cli::try_parse_from(["ttfx", "--palette", "#7aa2f7,#f7768e", "decrypt"]).unwrap();
+        assert_eq!(
+            cli.palette().unwrap().colors(),
+            &[color("#7aa2f7"), color("#f7768e")]
+        );
+        assert!(matches!(cli.effect, Some(EffectCommand::Decrypt(_))));
+    }
+
+    #[test]
+    fn palette_flag_is_repeatable_and_splits_whitespace() {
+        let cli = Cli::try_parse_from([
+            "ttfx",
+            "--palette",
+            "7aa2f7",
+            "--palette",
+            "c0caf5 f7768e",
+            "decrypt",
+        ])
+        .unwrap();
+        assert_eq!(
+            cli.palette().unwrap().colors(),
+            &[color("7aa2f7"), color("c0caf5"), color("f7768e")]
+        );
+    }
+
+    #[test]
+    fn palette_does_not_eat_the_effect_name() {
+        let cli = Cli::try_parse_from(["ttfx", "--palette", "7aa2f7", "decrypt"]).unwrap();
+        assert!(matches!(cli.effect, Some(EffectCommand::Decrypt(_))));
+        assert_eq!(cli.palette().unwrap().colors().len(), 1);
+    }
+
+    #[test]
+    fn palette_rejects_an_empty_value() {
+        assert!(Cli::try_parse_from(["ttfx", "--palette", ",", "decrypt"]).is_err());
+    }
+
+    #[test]
+    fn palette_rejects_invalid_hex() {
+        assert!(Cli::try_parse_from(["ttfx", "--palette", "not-a-color", "decrypt"]).is_err());
+    }
+
+    #[test]
+    fn apply_palette_recolors_default_decrypt_colors() {
+        let matches = Cli::command().get_matches_from([
+            "ttfx",
+            "--palette",
+            "ff0000,00ff00,0000ff",
+            "decrypt",
+        ]);
+        let mut cli = Cli::from_arg_matches(&matches).unwrap();
+        let palette = cli.palette().unwrap();
+        let mut effect = cli.effect.take().unwrap();
+        effect.apply_palette(
+            &palette,
+            &command_line_arg_ids(matches.subcommand().unwrap().1),
+        );
+        let config = decrypt_config(effect);
+        assert_eq!(
+            config.ciphertext_colors,
+            vec![color("ff0000"), color("00ff00"), color("0000ff")]
+        );
+        assert_eq!(config.final_gradient_stops, vec![color("ff0000")]);
+    }
+
+    #[test]
+    fn apply_palette_leaves_explicit_color_flags_alone() {
+        let matches = Cli::command().get_matches_from([
+            "ttfx",
+            "--palette",
+            "ff0000,00ff00",
+            "decrypt",
+            "--final-gradient-stops",
+            "ffffff",
+        ]);
+        let mut cli = Cli::from_arg_matches(&matches).unwrap();
+        let palette = cli.palette().unwrap();
+        let skip = command_line_arg_ids(matches.subcommand().unwrap().1);
+        let mut effect = cli.effect.take().unwrap();
+        effect.apply_palette(&palette, &skip);
+        let config = decrypt_config(effect);
+        assert_eq!(config.final_gradient_stops, vec![color("ffffff")]);
+        assert_eq!(
+            config.ciphertext_colors,
+            vec![color("ff0000"), color("00ff00"), color("ff0000")]
+        );
+    }
+
+    #[test]
+    fn palette_new_rejects_empty() {
+        assert!(Palette::new(Vec::new()).is_err());
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -181,6 +181,7 @@ impl Cli {
             reuse_canvas: self.reuse_canvas,
             no_eol: self.no_eol,
             no_restore_cursor: self.no_restore_cursor,
+            terminal_size: None,
         }
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,7 +6,7 @@ use clap::Parser;
 use crate::engine::animation::ExistingColorHandling;
 use crate::engine::canvas::Anchor;
 use crate::engine::terminal::TerminalConfig;
-use crate::utils::graphics::Color;
+use crate::utils::graphics::{parse_color, Color};
 
 fn parse_positive_int(s: &str) -> Result<i64, String> {
     let v: i64 = s.parse().map_err(|_| format!("invalid int value: '{s}'"))?;
@@ -32,16 +32,6 @@ fn parse_canvas_dimension(s: &str) -> Result<i64, String> {
         Ok(v)
     } else {
         Err(format!("{v} is not >= -1"))
-    }
-}
-
-/// argutils.ColorArg: <=3 chars -> xterm int 0-255, else hex.
-pub fn parse_color(s: &str) -> Result<Color, String> {
-    if s.len() <= 3 {
-        let code: u8 = s.parse().map_err(|_| format!("invalid color value: '{s}'"))?;
-        Ok(Color::from_xterm(code))
-    } else {
-        Color::from_hex(s)
     }
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -123,7 +123,7 @@ pub struct Cli {
     #[arg(long = "palette", value_name = "HEX[,HEX...]", action = clap::ArgAction::Append, value_parser = parse_palette_arg)]
     pub palette_args: Vec<Vec<Color>>,
 
-    /// Color the word in 4-3-4-3-5 field bands using --palette (crest, hover,
+    /// Color the word in 5-2-4-3-5 field bands using --palette (crest, hover,
     /// lit, mid, dim from the top). Requires --palette.
     #[arg(long = "bands", default_value_t = false)]
     pub bands: bool,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -123,7 +123,7 @@ pub struct Cli {
     #[arg(long = "palette", value_name = "HEX[,HEX...]", action = clap::ArgAction::Append, value_parser = parse_palette_arg)]
     pub palette_args: Vec<Vec<Color>>,
 
-    /// Color the word in 4-1-4-3-5 field bands using --palette (crest, hover,
+    /// Color the word in 4-3-4-3-5 field bands using --palette (crest, hover,
     /// lit, mid, dim from the top). Requires --palette.
     #[arg(long = "bands", default_value_t = false)]
     pub bands: bool,

--- a/src/effects/beams.rs
+++ b/src/effects/beams.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 
 use clap::Args;
 
-use crate::cli::parse_color;
 use crate::effects::common::{
     parse_gradient_direction, parse_gradient_steps, parse_positive_int, parse_positive_int_range, parse_symbol,
 };
@@ -15,7 +14,7 @@ use crate::engine::effect::Effect;
 use crate::engine::error::EngineError;
 use crate::engine::events::EffectCallback;
 use crate::engine::terminal::{CharacterFilter, CharacterGroup, CharacterSort};
-use crate::utils::graphics::{Color, ColorPair, Gradient, GradientDirection};
+use crate::utils::graphics::{parse_color, Color, ColorPair, Gradient, GradientDirection};
 
 #[derive(Args, Debug, Clone)]
 pub struct BeamsConfig {
@@ -76,6 +75,26 @@ pub struct BeamsConfig {
     /// Speed of the final wipe as measured in diagonal groups activated per frame.
     #[arg(long = "final-wipe-speed", default_value_t = 3, value_parser = parse_positive_int)]
     pub final_wipe_speed: i64,
+}
+
+impl Default for BeamsConfig {
+    fn default() -> Self {
+        Self {
+            beam_row_symbols: ["▂", "▁", "_"].into_iter().map(|v| parse_symbol(v).expect("default beam_row_symbols")).collect(),
+            beam_column_symbols: ["▌", "▍", "▎", "▏"].into_iter().map(|v| parse_symbol(v).expect("default beam_column_symbols")).collect(),
+            beam_delay: 6,
+            beam_row_speed_range: parse_positive_int_range("15-60").expect("default beam_row_speed_range"),
+            beam_column_speed_range: parse_positive_int_range("9-15").expect("default beam_column_speed_range"),
+            beam_gradient_stops: ["ffffff", "00D1FF", "8A008A"].into_iter().map(|v| parse_color(v).expect("default beam_gradient_stops")).collect(),
+            beam_gradient_steps: ["2", "6"].into_iter().map(|v| parse_gradient_steps(v).expect("default beam_gradient_steps")).collect(),
+            beam_gradient_frames: 2,
+            final_gradient_stops: ["8A008A", "00D1FF", "ffffff"].into_iter().map(|v| parse_color(v).expect("default final_gradient_stops")).collect(),
+            final_gradient_steps: ["12"].into_iter().map(|v| parse_gradient_steps(v).expect("default final_gradient_steps")).collect(),
+            final_gradient_frames: 4,
+            final_gradient_direction: parse_gradient_direction("vertical").expect("default final_gradient_direction"),
+            final_wipe_speed: 3,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/effects/binarypath.rs
+++ b/src/effects/binarypath.rs
@@ -8,7 +8,6 @@ use std::collections::HashMap;
 
 use clap::Args;
 
-use crate::cli::parse_color;
 use crate::effects::common::{
     parse_gradient_direction, parse_gradient_steps, parse_non_negative_ratio, parse_positive_float,
 };
@@ -21,7 +20,7 @@ use crate::engine::events::EffectCallback;
 use crate::engine::terminal::{CharacterFilter, CharacterGroup, CharacterSort};
 use crate::utils::easing::Easing;
 use crate::utils::geometry::Coord;
-use crate::utils::graphics::{Color, ColorPair, Gradient, GradientDirection};
+use crate::utils::graphics::{parse_color, Color, ColorPair, Gradient, GradientDirection};
 
 #[derive(Args, Debug, Clone)]
 pub struct BinaryPathConfig {
@@ -51,6 +50,19 @@ pub struct BinaryPathConfig {
     /// Maximum number of binary groups that are active at any given time as a percentage of the total number of binary groups. Lower this to improve performance.
     #[arg(long = "active-binary-groups", default_value_t = 0.08, value_parser = parse_non_negative_ratio)]
     pub active_binary_groups: f64,
+}
+
+impl Default for BinaryPathConfig {
+    fn default() -> Self {
+        Self {
+            final_gradient_stops: ["00d500", "007500"].into_iter().map(|v| parse_color(v).expect("default final_gradient_stops")).collect(),
+            final_gradient_steps: ["12"].into_iter().map(|v| parse_gradient_steps(v).expect("default final_gradient_steps")).collect(),
+            final_gradient_direction: parse_gradient_direction("radial").expect("default final_gradient_direction"),
+            binary_colors: ["044E29", "157e38", "45bf55", "95ed87"].into_iter().map(|v| parse_color(v).expect("default binary_colors")).collect(),
+            movement_speed: 1.0,
+            active_binary_groups: 0.08,
+        }
+    }
 }
 
 /// BinaryPathIterator._BinaryRepresentation.

--- a/src/effects/blackhole.rs
+++ b/src/effects/blackhole.rs
@@ -4,7 +4,6 @@ use std::collections::{HashMap, HashSet};
 
 use clap::Args;
 
-use crate::cli::parse_color;
 use crate::effects::common::{parse_gradient_direction, parse_gradient_steps};
 use crate::engine::animation::{ExistingColorHandling, SyncMetric, VisualParams};
 use crate::engine::character::CharId;
@@ -15,7 +14,7 @@ use crate::engine::events::{CallerKey, EffectCallback, Event, EventAction};
 use crate::engine::terminal::{CharacterFilter, CharacterSort};
 use crate::utils::easing::Easing;
 use crate::utils::geometry;
-use crate::utils::graphics::{Color, ColorPair, Gradient, GradientDirection};
+use crate::utils::graphics::{parse_color, Color, ColorPair, Gradient, GradientDirection};
 use crate::utils::pycompat::{floor_div, round_half_even};
 
 #[derive(Args, Debug, Clone)]
@@ -42,6 +41,18 @@ pub struct BlackholeConfig {
     /// Direction of the final gradient.
     #[arg(long = "final-gradient-direction", default_value = "diagonal", value_parser = parse_gradient_direction)]
     pub final_gradient_direction: GradientDirection,
+}
+
+impl Default for BlackholeConfig {
+    fn default() -> Self {
+        Self {
+            blackhole_color: parse_color("ffffff").expect("default blackhole_color"),
+            star_colors: ["ffcc0d", "ff7326", "ff194d", "bf2669", "702a8c", "049dbf"].into_iter().map(|v| parse_color(v).expect("default star_colors")).collect(),
+            final_gradient_stops: ["8A008A", "00D1FF", "ffffff"].into_iter().map(|v| parse_color(v).expect("default final_gradient_stops")).collect(),
+            final_gradient_steps: ["9"].into_iter().map(|v| parse_gradient_steps(v).expect("default final_gradient_steps")).collect(),
+            final_gradient_direction: parse_gradient_direction("diagonal").expect("default final_gradient_direction"),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/src/effects/bouncyballs.rs
+++ b/src/effects/bouncyballs.rs
@@ -4,7 +4,6 @@ use std::collections::{BTreeMap, HashMap};
 
 use clap::Args;
 
-use crate::cli::parse_color;
 use crate::effects::common::{
     parse_easing, parse_gradient_direction, parse_gradient_steps, parse_non_negative_int, parse_positive_float,
     parse_symbol,
@@ -18,7 +17,7 @@ use crate::engine::events::{CallerKey, EffectCallback, Event, EventAction};
 use crate::engine::terminal::{CharacterFilter, CharacterSort};
 use crate::utils::easing::Easing;
 use crate::utils::geometry::Coord;
-use crate::utils::graphics::{Color, ColorPair, Gradient, GradientDirection};
+use crate::utils::graphics::{parse_color, Color, ColorPair, Gradient, GradientDirection};
 
 #[derive(Args, Debug, Clone)]
 pub struct BouncyBallsConfig {
@@ -57,6 +56,21 @@ pub struct BouncyBallsConfig {
     /// Direction of the final gradient.
     #[arg(long = "final-gradient-direction", default_value = "diagonal", value_parser = parse_gradient_direction)]
     pub final_gradient_direction: GradientDirection,
+}
+
+impl Default for BouncyBallsConfig {
+    fn default() -> Self {
+        Self {
+            ball_colors: ["d1f4a5", "96e2a4", "5acda9"].into_iter().map(|v| parse_color(v).expect("default ball_colors")).collect(),
+            ball_symbols: ["*", "o", "O", "0", "."].into_iter().map(|v| parse_symbol(v).expect("default ball_symbols")).collect(),
+            ball_delay: 4,
+            movement_speed: 0.45,
+            movement_easing: parse_easing("out_bounce").expect("default movement_easing"),
+            final_gradient_stops: ["f8ffae", "43c6ac"].into_iter().map(|v| parse_color(v).expect("default final_gradient_stops")).collect(),
+            final_gradient_steps: ["12"].into_iter().map(|v| parse_gradient_steps(v).expect("default final_gradient_steps")).collect(),
+            final_gradient_direction: parse_gradient_direction("diagonal").expect("default final_gradient_direction"),
+        }
+    }
 }
 
 pub struct BouncyBalls {

--- a/src/effects/bubbles.rs
+++ b/src/effects/bubbles.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 
 use clap::Args;
 
-use crate::cli::parse_color;
 use crate::effects::common::{
     parse_easing, parse_gradient_direction, parse_gradient_steps, parse_positive_float, parse_positive_int,
 };
@@ -17,7 +16,7 @@ use crate::engine::events::{CallerKey, EffectCallback, Event, EventAction};
 use crate::engine::terminal::{CharacterFilter, CharacterGroup, CharacterSort};
 use crate::utils::easing::Easing;
 use crate::utils::geometry::{self, Coord};
-use crate::utils::graphics::{Color, ColorPair, Gradient, GradientDirection};
+use crate::utils::graphics::{parse_color, Color, ColorPair, Gradient, GradientDirection};
 
 /// pop_condition choices.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -80,6 +79,23 @@ pub struct BubblesConfig {
     /// Direction of the final gradient.
     #[arg(long = "final-gradient-direction", default_value = "diagonal", value_parser = parse_gradient_direction)]
     pub final_gradient_direction: GradientDirection,
+}
+
+impl Default for BubblesConfig {
+    fn default() -> Self {
+        Self {
+            rainbow: false,
+            bubble_colors: ["d33aff", "7395c4", "43c2a7", "02ff7f"].into_iter().map(|v| parse_color(v).expect("default bubble_colors")).collect(),
+            pop_color: parse_color("ffffff").expect("default pop_color"),
+            bubble_speed: 0.5,
+            bubble_delay: 20,
+            pop_condition: parse_pop_condition("row").expect("default pop_condition"),
+            movement_easing: parse_easing("in_out_sine").expect("default movement_easing"),
+            final_gradient_stops: ["d33aff", "02ff7f"].into_iter().map(|v| parse_color(v).expect("default final_gradient_stops")).collect(),
+            final_gradient_steps: ["12"].into_iter().map(|v| parse_gradient_steps(v).expect("default final_gradient_steps")).collect(),
+            final_gradient_direction: parse_gradient_direction("diagonal").expect("default final_gradient_direction"),
+        }
+    }
 }
 
 /// BubblesIterator.Bubble state (methods live on Bubbles for hooks access).

--- a/src/effects/burn.rs
+++ b/src/effects/burn.rs
@@ -13,7 +13,6 @@ use std::collections::HashMap;
 
 use clap::Args;
 
-use crate::cli::parse_color;
 use crate::effects::common::{parse_gradient_direction, parse_gradient_steps, parse_non_negative_ratio};
 use crate::engine::animation::{ExistingColorHandling, VisualParams};
 use crate::engine::character::CharId;
@@ -24,7 +23,7 @@ use crate::engine::events::{CallbackValue, CallerKey, EffectCallback, Event, Eve
 use crate::engine::particles::{ParticlePool, ParticleReset};
 use crate::engine::terminal::{CharacterFilter, CharacterSort};
 use crate::utils::geometry::Coord;
-use crate::utils::graphics::{Color, ColorPair, Gradient, GradientDirection};
+use crate::utils::graphics::{parse_color, Color, ColorPair, Gradient, GradientDirection};
 use crate::utils::spanning_tree::PrimsSimple;
 
 /// Callback id: EventHandler.Callback(lambda c: self._emit_smoke(c.input_coord, ...)).
@@ -60,6 +59,19 @@ pub struct BurnConfig {
     /// Direction of the final gradient.
     #[arg(long = "final-gradient-direction", default_value = "vertical", value_parser = parse_gradient_direction)]
     pub final_gradient_direction: GradientDirection,
+}
+
+impl Default for BurnConfig {
+    fn default() -> Self {
+        Self {
+            starting_color: parse_color("837373").expect("default starting_color"),
+            burn_colors: ["ffffff", "fff75d", "fe650d", "8A003C", "510100"].into_iter().map(|v| parse_color(v).expect("default burn_colors")).collect(),
+            smoke_chance: 0.5,
+            final_gradient_stops: ["00c3ff", "ffff1c"].into_iter().map(|v| parse_color(v).expect("default final_gradient_stops")).collect(),
+            final_gradient_steps: ["12"].into_iter().map(|v| parse_gradient_steps(v).expect("default final_gradient_steps")).collect(),
+            final_gradient_direction: parse_gradient_direction("vertical").expect("default final_gradient_direction"),
+        }
+    }
 }
 
 const BURN_CHAR_ORDER: [&str; 9] = ["'", ".", "▖", "▙", "█", "▜", "▀", "▝", "."];

--- a/src/effects/colorshift.rs
+++ b/src/effects/colorshift.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 
 use clap::Args;
 
-use crate::cli::parse_color;
 use crate::effects::common::{parse_gradient_direction, parse_gradient_steps, parse_positive_int};
 use crate::engine::animation::{ExistingColorHandling, VisualParams};
 use crate::engine::character::CharId;
@@ -14,7 +13,7 @@ use crate::engine::error::EngineError;
 use crate::engine::events::{CallerKey, EffectCallback, Event, EventAction};
 use crate::engine::terminal::{CharacterFilter, CharacterSort};
 use crate::utils::geometry;
-use crate::utils::graphics::{Color, ColorPair, Gradient, GradientDirection};
+use crate::utils::graphics::{parse_color, Color, ColorPair, Gradient, GradientDirection};
 
 #[derive(Args, Debug, Clone)]
 pub struct ColorShiftConfig {
@@ -69,6 +68,25 @@ pub struct ColorShiftConfig {
     /// Direction of the final gradient.
     #[arg(long = "final-gradient-direction", default_value = "vertical", value_parser = parse_gradient_direction)]
     pub final_gradient_direction: GradientDirection,
+}
+
+impl Default for ColorShiftConfig {
+    fn default() -> Self {
+        Self {
+            gradient_stops: ["e81416", "ffa500", "faeb36", "79c314", "487de7", "4b369d", "70369d"].into_iter().map(|v| parse_color(v).expect("default gradient_stops")).collect(),
+            gradient_steps: ["12"].into_iter().map(|v| parse_gradient_steps(v).expect("default gradient_steps")).collect(),
+            gradient_frames: 2,
+            no_travel: false,
+            travel_direction: parse_gradient_direction("radial").expect("default travel_direction"),
+            reverse_travel_direction: false,
+            no_loop: false,
+            cycles: 3,
+            skip_final_gradient: false,
+            final_gradient_stops: ["e81416", "ffa500", "faeb36", "79c314", "487de7", "4b369d", "70369d"].into_iter().map(|v| parse_color(v).expect("default final_gradient_stops")).collect(),
+            final_gradient_steps: ["12"].into_iter().map(|v| parse_gradient_steps(v).expect("default final_gradient_steps")).collect(),
+            final_gradient_direction: parse_gradient_direction("vertical").expect("default final_gradient_direction"),
+        }
+    }
 }
 
 pub struct ColorShift {

--- a/src/effects/crumble.rs
+++ b/src/effects/crumble.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 
 use clap::Args;
 
-use crate::cli::parse_color;
 use crate::effects::common::{parse_gradient_direction, parse_gradient_steps};
 use crate::engine::animation::{Animation, ExistingColorHandling, SyncMetric, VisualParams};
 use crate::engine::character::CharId;
@@ -15,7 +14,7 @@ use crate::engine::events::{CallerKey, EffectCallback, Event, EventAction};
 use crate::engine::terminal::{CharacterFilter, CharacterSort};
 use crate::utils::easing::Easing;
 use crate::utils::geometry::Coord;
-use crate::utils::graphics::{Color, ColorPair, Gradient, GradientDirection};
+use crate::utils::graphics::{parse_color, Color, ColorPair, Gradient, GradientDirection};
 
 #[derive(Args, Debug, Clone)]
 pub struct CrumbleConfig {
@@ -32,6 +31,16 @@ pub struct CrumbleConfig {
     /// Direction of the final gradient.
     #[arg(long = "final-gradient-direction", default_value = "diagonal", value_parser = parse_gradient_direction)]
     pub final_gradient_direction: GradientDirection,
+}
+
+impl Default for CrumbleConfig {
+    fn default() -> Self {
+        Self {
+            final_gradient_stops: ["5CE1FF", "FF8C00"].into_iter().map(|v| parse_color(v).expect("default final_gradient_stops")).collect(),
+            final_gradient_steps: ["12"].into_iter().map(|v| parse_gradient_steps(v).expect("default final_gradient_steps")).collect(),
+            final_gradient_direction: parse_gradient_direction("diagonal").expect("default final_gradient_direction"),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/src/effects/decrypt.rs
+++ b/src/effects/decrypt.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 
 use clap::Args;
 
-use crate::cli::parse_color;
 use crate::effects::common::{parse_gradient_direction, parse_gradient_steps, parse_positive_int};
 use crate::engine::animation::{ExistingColorHandling, VisualParams};
 use crate::engine::character::CharId;
@@ -13,7 +12,7 @@ use crate::engine::effect::Effect;
 use crate::engine::error::EngineError;
 use crate::engine::events::{CallerKey, EffectCallback, Event, EventAction};
 use crate::engine::terminal::{CharacterFilter, CharacterSort};
-use crate::utils::graphics::{Color, ColorPair, Gradient, GradientDirection};
+use crate::utils::graphics::{parse_color, Color, ColorPair, Gradient, GradientDirection};
 
 #[derive(Args, Debug, Clone)]
 pub struct DecryptConfig {
@@ -39,6 +38,28 @@ pub struct DecryptConfig {
     /// Direction of the final gradient.
     #[arg(long = "final-gradient-direction", default_value = "vertical", value_parser = parse_gradient_direction)]
     pub final_gradient_direction: GradientDirection,
+}
+
+impl Default for DecryptConfig {
+    fn default() -> Self {
+        Self {
+            typing_speed: 2,
+            ciphertext_colors: ["008000", "00cb00", "00ff00"]
+                .into_iter()
+                .map(|v| parse_color(v).expect("default ciphertext_colors"))
+                .collect(),
+            final_gradient_stops: ["eda000"]
+                .into_iter()
+                .map(|v| parse_color(v).expect("default final_gradient_stops"))
+                .collect(),
+            final_gradient_steps: ["12"]
+                .into_iter()
+                .map(|v| parse_gradient_steps(v).expect("default final_gradient_steps"))
+                .collect(),
+            final_gradient_direction: parse_gradient_direction("vertical")
+                .expect("default final_gradient_direction"),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/effects/errorcorrect.rs
+++ b/src/effects/errorcorrect.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 
 use clap::Args;
 
-use crate::cli::parse_color;
 use crate::effects::common::{
     parse_gradient_direction, parse_gradient_steps, parse_positive_float, parse_positive_int,
 };
@@ -15,7 +14,7 @@ use crate::engine::effect::Effect;
 use crate::engine::error::EngineError;
 use crate::engine::events::{CallerKey, EffectCallback, Event, EventAction};
 use crate::engine::terminal::{CharacterFilter, CharacterSort};
-use crate::utils::graphics::{Color, ColorPair, Gradient, GradientDirection};
+use crate::utils::graphics::{parse_color, Color, ColorPair, Gradient, GradientDirection};
 
 #[derive(Args, Debug, Clone)]
 pub struct ErrorCorrectConfig {
@@ -52,6 +51,21 @@ pub struct ErrorCorrectConfig {
     /// Direction of the final gradient.
     #[arg(long = "final-gradient-direction", default_value = "vertical", value_parser = parse_gradient_direction)]
     pub final_gradient_direction: GradientDirection,
+}
+
+impl Default for ErrorCorrectConfig {
+    fn default() -> Self {
+        Self {
+            error_pairs: 0.1,
+            swap_delay: 6,
+            error_color: parse_color("e74c3c").expect("default error_color"),
+            correct_color: parse_color("45bf55").expect("default correct_color"),
+            movement_speed: 0.9,
+            final_gradient_stops: ["8A008A", "00D1FF", "FFFFFF"].into_iter().map(|v| parse_color(v).expect("default final_gradient_stops")).collect(),
+            final_gradient_steps: ["12"].into_iter().map(|v| parse_gradient_steps(v).expect("default final_gradient_steps")).collect(),
+            final_gradient_direction: parse_gradient_direction("vertical").expect("default final_gradient_direction"),
+        }
+    }
 }
 
 const BLOCK_WIPE_START: [&str; 8] = ["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"];

--- a/src/effects/expand.rs
+++ b/src/effects/expand.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 
 use clap::Args;
 
-use crate::cli::parse_color;
 use crate::effects::common::{parse_easing, parse_gradient_direction, parse_gradient_steps, parse_positive_float};
 use crate::engine::animation::{ExistingColorHandling, SyncMetric, VisualParams};
 use crate::engine::character::CharId;
@@ -14,7 +13,7 @@ use crate::engine::error::EngineError;
 use crate::engine::events::{CallerKey, EffectCallback, Event, EventAction};
 use crate::engine::terminal::{CharacterFilter, CharacterSort};
 use crate::utils::easing::Easing;
-use crate::utils::graphics::{Color, ColorPair, Gradient, GradientDirection};
+use crate::utils::graphics::{parse_color, Color, ColorPair, Gradient, GradientDirection};
 
 #[derive(Args, Debug, Clone)]
 pub struct ExpandConfig {
@@ -39,6 +38,18 @@ pub struct ExpandConfig {
     /// Direction of the final gradient.
     #[arg(long = "final-gradient-direction", default_value = "vertical", value_parser = parse_gradient_direction)]
     pub final_gradient_direction: GradientDirection,
+}
+
+impl Default for ExpandConfig {
+    fn default() -> Self {
+        Self {
+            expand_easing: parse_easing("in_out_quart").expect("default expand_easing"),
+            movement_speed: 0.35,
+            final_gradient_stops: ["8A008A", "00D1FF", "FFFFFF"].into_iter().map(|v| parse_color(v).expect("default final_gradient_stops")).collect(),
+            final_gradient_steps: ["12"].into_iter().map(|v| parse_gradient_steps(v).expect("default final_gradient_steps")).collect(),
+            final_gradient_direction: parse_gradient_direction("vertical").expect("default final_gradient_direction"),
+        }
+    }
 }
 
 pub struct Expand {

--- a/src/effects/fireworks.rs
+++ b/src/effects/fireworks.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 
 use clap::Args;
 
-use crate::cli::parse_color;
 use crate::effects::common::{
     parse_gradient_direction, parse_gradient_steps, parse_non_negative_int, parse_non_negative_ratio, parse_symbol,
 };
@@ -17,7 +16,7 @@ use crate::engine::events::{CallerKey, EffectCallback, Event, EventAction};
 use crate::engine::terminal::{CharacterFilter, CharacterSort};
 use crate::utils::easing::Easing;
 use crate::utils::geometry::{self, Coord};
-use crate::utils::graphics::{Color, ColorPair, Gradient, GradientDirection};
+use crate::utils::graphics::{parse_color, Color, ColorPair, Gradient, GradientDirection};
 use crate::utils::pycompat::{floor_div, round_half_even};
 
 #[derive(Args, Debug, Clone)]
@@ -60,6 +59,22 @@ pub struct FireworksConfig {
     /// Direction of the final gradient.
     #[arg(long = "final-gradient-direction", default_value = "horizontal", value_parser = parse_gradient_direction)]
     pub final_gradient_direction: GradientDirection,
+}
+
+impl Default for FireworksConfig {
+    fn default() -> Self {
+        Self {
+            explode_anywhere: false,
+            firework_colors: ["88F7E2", "44D492", "F5EB67", "FFA15C", "FA233E"].into_iter().map(|v| parse_color(v).expect("default firework_colors")).collect(),
+            firework_symbol: parse_symbol("o").expect("default firework_symbol"),
+            firework_volume: 0.05,
+            launch_delay: 45,
+            explode_distance: 0.2,
+            final_gradient_stops: ["8A008A", "00D1FF", "FFFFFF"].into_iter().map(|v| parse_color(v).expect("default final_gradient_stops")).collect(),
+            final_gradient_steps: ["12"].into_iter().map(|v| parse_gradient_steps(v).expect("default final_gradient_steps")).collect(),
+            final_gradient_direction: parse_gradient_direction("horizontal").expect("default final_gradient_direction"),
+        }
+    }
 }
 
 pub struct Fireworks {

--- a/src/effects/highlight.rs
+++ b/src/effects/highlight.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 
 use clap::Args;
 
-use crate::cli::parse_color;
 use crate::effects::common::{
     parse_character_group, parse_gradient_direction, parse_gradient_steps, parse_positive_float, parse_positive_int,
 };
@@ -16,7 +15,7 @@ use crate::engine::error::EngineError;
 use crate::engine::events::EffectCallback;
 use crate::engine::terminal::{CharacterFilter, CharacterGroup, CharacterSort};
 use crate::utils::easing::{Easing, SequenceEaser};
-use crate::utils::graphics::{Color, ColorPair, Gradient, GradientDirection};
+use crate::utils::graphics::{parse_color, Color, ColorPair, Gradient, GradientDirection};
 
 #[derive(Args, Debug, Clone)]
 pub struct HighlightConfig {
@@ -46,6 +45,19 @@ pub struct HighlightConfig {
     /// Direction of the final gradient.
     #[arg(long = "final-gradient-direction", default_value = "vertical", value_parser = parse_gradient_direction)]
     pub final_gradient_direction: GradientDirection,
+}
+
+impl Default for HighlightConfig {
+    fn default() -> Self {
+        Self {
+            highlight_brightness: 1.75,
+            highlight_direction: parse_character_group("diagonal_bottom_left_to_top_right").expect("default highlight_direction"),
+            highlight_width: 8,
+            final_gradient_stops: ["8A008A", "00D1FF", "FFFFFF"].into_iter().map(|v| parse_color(v).expect("default final_gradient_stops")).collect(),
+            final_gradient_steps: ["12"].into_iter().map(|v| parse_gradient_steps(v).expect("default final_gradient_steps")).collect(),
+            final_gradient_direction: parse_gradient_direction("vertical").expect("default final_gradient_direction"),
+        }
+    }
 }
 
 pub struct Highlight {

--- a/src/effects/laseretch.rs
+++ b/src/effects/laseretch.rs
@@ -21,7 +21,6 @@ use std::collections::{HashMap, VecDeque};
 
 use clap::Args;
 
-use crate::cli::parse_color;
 use crate::effects::common::{
     parse_gradient_direction, parse_gradient_steps, parse_non_negative_int, parse_positive_int,
 };
@@ -35,7 +34,7 @@ use crate::engine::particles::{ParticlePool, ParticleReset};
 use crate::engine::terminal::{CharacterFilter, CharacterGroup, CharacterSort};
 use crate::utils::easing::Easing;
 use crate::utils::geometry::Coord;
-use crate::utils::graphics::{Color, ColorPair, Gradient, GradientDirection};
+use crate::utils::graphics::{parse_color, Color, ColorPair, Gradient, GradientDirection};
 use crate::utils::spanning_tree::RecursiveBacktracker;
 
 /// Callback id: sparks_pool.reclaim(spark, hide=True, deactivate=True).
@@ -106,6 +105,24 @@ pub struct LaserEtchConfig {
     /// Direction of the final gradient.
     #[arg(long = "final-gradient-direction", default_value = "vertical", value_parser = parse_gradient_direction)]
     pub final_gradient_direction: GradientDirection,
+}
+
+impl Default for LaserEtchConfig {
+    fn default() -> Self {
+        Self {
+            etch_pattern: parse_etch_pattern("algorithm").expect("default etch_pattern"),
+            etch_speed: 1,
+            etch_delay: 1,
+            cool_gradient_stops: ["ffe680", "ff7b00"].into_iter().map(|v| parse_color(v).expect("default cool_gradient_stops")).collect(),
+            laser_gradient_stops: ["ffffff", "376cff"].into_iter().map(|v| parse_color(v).expect("default laser_gradient_stops")).collect(),
+            spark_gradient_stops: ["ffffff", "ffe680", "ff7b00", "1a0900"].into_iter().map(|v| parse_color(v).expect("default spark_gradient_stops")).collect(),
+            spark_cooling_frames: 7,
+            final_gradient_stops: ["8A008A", "00D1FF", "ffffff"].into_iter().map(|v| parse_color(v).expect("default final_gradient_stops")).collect(),
+            final_gradient_steps: ["8"].into_iter().map(|v| parse_gradient_steps(v).expect("default final_gradient_steps")).collect(),
+            final_gradient_frames: 4,
+            final_gradient_direction: parse_gradient_direction("vertical").expect("default final_gradient_direction"),
+        }
+    }
 }
 
 /// LaserEtchIterator.Laser state (methods live on LaserEtch for hooks access).

--- a/src/effects/matrix.rs
+++ b/src/effects/matrix.rs
@@ -15,7 +15,6 @@ use std::collections::HashMap;
 
 use clap::Args;
 
-use crate::cli::parse_color;
 use crate::effects::common::{
     parse_gradient_direction, parse_gradient_steps, parse_positive_float, parse_positive_int,
     parse_positive_int_range, parse_symbol,
@@ -28,7 +27,7 @@ use crate::engine::error::EngineError;
 use crate::engine::events::EffectCallback;
 use crate::engine::terminal::{CharacterFilter, CharacterGroup, CharacterSort};
 use crate::utils::geometry::Coord;
-use crate::utils::graphics::{Color, ColorPair, Gradient, GradientDirection};
+use crate::utils::graphics::{parse_color, Color, ColorPair, Gradient, GradientDirection};
 use crate::utils::pycompat::floor_div;
 
 #[derive(Args, Debug, Clone)]
@@ -93,6 +92,31 @@ pub struct MatrixConfig {
     /// Direction of the final gradient.
     #[arg(long = "final-gradient-direction", default_value = "radial", value_parser = parse_gradient_direction)]
     pub final_gradient_direction: GradientDirection,
+}
+
+impl Default for MatrixConfig {
+    fn default() -> Self {
+        Self {
+            highlight_color: parse_color("dbffdb").expect("default highlight_color"),
+            rain_color_gradient: ["92be92", "185318"].into_iter().map(|v| parse_color(v).expect("default rain_color_gradient")).collect(),
+            rain_symbols: [
+              "2", "5", "9", "8", "Z", "*", ")", ":", ".", "\"", "=", "+", "-", "¦", "|", "_",
+              "ｦ", "ｱ", "ｳ", "ｴ", "ｵ", "ｶ", "ｷ", "ｹ", "ｺ", "ｻ", "ｼ", "ｽ", "ｾ", "ｿ", "ﾀ", "ﾂ",
+              "ﾃ", "ﾅ", "ﾆ", "ﾇ", "ﾈ", "ﾊ", "ﾋ", "ﾎ", "ﾏ", "ﾐ", "ﾑ", "ﾒ", "ﾓ", "ﾔ", "ﾕ", "ﾗ",
+              "ﾘ", "ﾜ",
+          ].into_iter().map(|v| parse_symbol(v).expect("default rain_symbols")).collect(),
+            rain_fall_delay_range: parse_positive_int_range("2-15").expect("default rain_fall_delay_range"),
+            rain_column_delay_range: parse_positive_int_range("3-9").expect("default rain_column_delay_range"),
+            rain_time: 15,
+            symbol_swap_chance: 0.005,
+            color_swap_chance: 0.001,
+            resolve_delay: 3,
+            final_gradient_stops: ["92be92", "336b33"].into_iter().map(|v| parse_color(v).expect("default final_gradient_stops")).collect(),
+            final_gradient_steps: ["12"].into_iter().map(|v| parse_gradient_steps(v).expect("default final_gradient_steps")).collect(),
+            final_gradient_frames: 3,
+            final_gradient_direction: parse_gradient_direction("radial").expect("default final_gradient_direction"),
+        }
+    }
 }
 
 /// Animation.set_appearance shorthand (upstream character.animation.set_appearance).

--- a/src/effects/middleout.rs
+++ b/src/effects/middleout.rs
@@ -10,7 +10,6 @@ use std::collections::HashMap;
 
 use clap::Args;
 
-use crate::cli::parse_color;
 use crate::effects::common::{parse_easing, parse_gradient_direction, parse_gradient_steps, parse_positive_float};
 use crate::engine::animation::{ExistingColorHandling, VisualParams};
 use crate::engine::character::CharId;
@@ -21,7 +20,7 @@ use crate::engine::events::EffectCallback;
 use crate::engine::terminal::{CharacterFilter, CharacterSort};
 use crate::utils::easing::Easing;
 use crate::utils::geometry::Coord;
-use crate::utils::graphics::{Color, ColorPair, Gradient, GradientDirection};
+use crate::utils::graphics::{parse_color, Color, ColorPair, Gradient, GradientDirection};
 
 /// typing.Literal["vertical", "horizontal"].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -77,6 +76,22 @@ pub struct MiddleoutConfig {
     /// Direction of the final gradient.
     #[arg(long = "final-gradient-direction", default_value = "vertical", value_parser = parse_gradient_direction)]
     pub final_gradient_direction: GradientDirection,
+}
+
+impl Default for MiddleoutConfig {
+    fn default() -> Self {
+        Self {
+            starting_color: parse_color("ffffff").expect("default starting_color"),
+            expand_direction: parse_expand_direction("vertical").expect("default expand_direction"),
+            center_movement_speed: 0.6,
+            full_movement_speed: 0.6,
+            center_easing: parse_easing("in_out_sine").expect("default center_easing"),
+            full_easing: parse_easing("in_out_sine").expect("default full_easing"),
+            final_gradient_stops: ["8A008A", "00D1FF", "FFFFFF"].into_iter().map(|v| parse_color(v).expect("default final_gradient_stops")).collect(),
+            final_gradient_steps: ["12"].into_iter().map(|v| parse_gradient_steps(v).expect("default final_gradient_steps")).collect(),
+            final_gradient_direction: parse_gradient_direction("vertical").expect("default final_gradient_direction"),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/effects/mod.rs
+++ b/src/effects/mod.rs
@@ -71,6 +71,21 @@ macro_rules! define_effects {
                     _ => None,
                 }
             }
+
+            pub fn apply_palette(
+                &mut self,
+                palette: &crate::utils::palette::Palette,
+                skip: &::std::collections::HashSet<String>,
+            ) {
+                match self {
+                    $(
+                        #[cfg(feature = $name)]
+                        EffectCommand::$variant(config) => {
+                            crate::utils::palette::ApplyPalette::apply_palette(config, palette, skip)
+                        }
+                    )*
+                }
+            }
         }
 
         pub fn catalog_entries() -> &'static [(&'static str, &'static str)] {
@@ -83,10 +98,27 @@ macro_rules! define_effects {
         }
 
         pub fn build_named_effect(name: &str) -> Option<Box<dyn Effect>> {
+            build_named_effect_with_palette(name, None)
+        }
+
+        pub fn build_named_effect_with_palette(
+            name: &str,
+            palette: Option<&crate::utils::palette::Palette>,
+        ) -> Option<Box<dyn Effect>> {
             match name {
                 $(
                     #[cfg(feature = $name)]
-                    $name => Some(Box::new($mod::$effect::new($mod::$config::default()))),
+                    $name => {
+                        let mut config = $mod::$config::default();
+                        if let Some(palette) = palette {
+                            crate::utils::palette::ApplyPalette::apply_palette(
+                                &mut config,
+                                palette,
+                                &::std::collections::HashSet::new(),
+                            );
+                        }
+                        Some(Box::new($mod::$effect::new(config)))
+                    }
                 )*
                 _ => None,
             }
@@ -136,6 +168,216 @@ define_effects! {
     "waves", waves, Waves, WavesConfig, Waves, "Waves travel across the terminal leaving behind the characters.";
     "wipe", wipe, Wipe, WipeConfig, Wipe, "Wipes the text across the terminal to reveal characters.";
 }
+
+macro_rules! impl_apply_palette {
+    ($feature:literal, $ty:ty, $($field:ident),+ $(,)?) => {
+        #[cfg(feature = $feature)]
+        impl crate::utils::palette::ApplyPalette for $ty {
+            fn apply_palette(
+                &mut self,
+                palette: &crate::utils::palette::Palette,
+                skip: &::std::collections::HashSet<String>,
+            ) {
+                let mut single_index = 0usize;
+                $(
+                    if !skip.contains(stringify!($field)) {
+                        crate::utils::palette::Recolor::recolor(
+                            &mut self.$field,
+                            palette,
+                            &mut single_index,
+                        );
+                    }
+                )+
+            }
+        }
+    };
+}
+
+impl_apply_palette!(
+    "beams",
+    beams::BeamsConfig,
+    beam_gradient_stops,
+    final_gradient_stops
+);
+impl_apply_palette!(
+    "binarypath",
+    binarypath::BinaryPathConfig,
+    final_gradient_stops,
+    binary_colors
+);
+impl_apply_palette!(
+    "blackhole",
+    blackhole::BlackholeConfig,
+    blackhole_color,
+    star_colors,
+    final_gradient_stops
+);
+impl_apply_palette!(
+    "bouncyballs",
+    bouncyballs::BouncyBallsConfig,
+    ball_colors,
+    final_gradient_stops
+);
+impl_apply_palette!(
+    "bubbles",
+    bubbles::BubblesConfig,
+    bubble_colors,
+    pop_color,
+    final_gradient_stops
+);
+impl_apply_palette!(
+    "burn",
+    burn::BurnConfig,
+    starting_color,
+    burn_colors,
+    final_gradient_stops
+);
+impl_apply_palette!(
+    "colorshift",
+    colorshift::ColorShiftConfig,
+    gradient_stops,
+    final_gradient_stops
+);
+impl_apply_palette!("crumble", crumble::CrumbleConfig, final_gradient_stops);
+impl_apply_palette!(
+    "decrypt",
+    decrypt::DecryptConfig,
+    ciphertext_colors,
+    final_gradient_stops
+);
+impl_apply_palette!(
+    "errorcorrect",
+    errorcorrect::ErrorCorrectConfig,
+    error_color,
+    correct_color,
+    final_gradient_stops
+);
+impl_apply_palette!("expand", expand::ExpandConfig, final_gradient_stops);
+impl_apply_palette!(
+    "fireworks",
+    fireworks::FireworksConfig,
+    firework_colors,
+    final_gradient_stops
+);
+impl_apply_palette!(
+    "highlight",
+    highlight::HighlightConfig,
+    final_gradient_stops
+);
+impl_apply_palette!(
+    "laseretch",
+    laseretch::LaserEtchConfig,
+    cool_gradient_stops,
+    laser_gradient_stops,
+    spark_gradient_stops,
+    final_gradient_stops
+);
+impl_apply_palette!(
+    "matrix",
+    matrix::MatrixConfig,
+    highlight_color,
+    rain_color_gradient,
+    final_gradient_stops
+);
+impl_apply_palette!(
+    "middleout",
+    middleout::MiddleoutConfig,
+    starting_color,
+    final_gradient_stops
+);
+impl_apply_palette!(
+    "orbittingvolley",
+    orbittingvolley::OrbittingVolleyConfig,
+    final_gradient_stops
+);
+impl_apply_palette!(
+    "overflow",
+    overflow::OverflowConfig,
+    overflow_gradient_stops,
+    final_gradient_stops
+);
+impl_apply_palette!(
+    "pour",
+    pour::PourConfig,
+    starting_color,
+    final_gradient_stops
+);
+impl_apply_palette!("print", print_effect::PrintConfig, final_gradient_stops);
+impl_apply_palette!("rain", rain::RainConfig, rain_colors, final_gradient_stops);
+impl_apply_palette!(
+    "randomsequence",
+    random_sequence::RandomSequenceConfig,
+    final_gradient_stops
+);
+impl_apply_palette!(
+    "rings",
+    rings::RingsConfig,
+    ring_colors,
+    final_gradient_stops
+);
+impl_apply_palette!(
+    "scattered",
+    scattered::ScatteredConfig,
+    final_gradient_stops
+);
+impl_apply_palette!("slice", slice::SliceConfig, final_gradient_stops);
+impl_apply_palette!("slide", slide::SlideConfig, final_gradient_stops);
+impl_apply_palette!(
+    "smoke",
+    smoke::SmokeConfig,
+    starting_color,
+    smoke_gradient_stops,
+    final_gradient_stops
+);
+impl_apply_palette!(
+    "spotlights",
+    spotlights::SpotlightsConfig,
+    final_gradient_stops
+);
+impl_apply_palette!("spray", spray::SprayConfig, final_gradient_stops);
+impl_apply_palette!(
+    "swarm",
+    swarm::SwarmConfig,
+    base_color,
+    flash_color,
+    final_gradient_stops
+);
+impl_apply_palette!("sweep", sweep::SweepConfig, final_gradient_stops);
+impl_apply_palette!(
+    "synthgrid",
+    synthgrid::SynthGridConfig,
+    grid_gradient_stops,
+    text_gradient_stops
+);
+impl_apply_palette!(
+    "thunderstorm",
+    thunderstorm::ThunderstormConfig,
+    lightning_color,
+    glowing_text_color,
+    spark_glow_color,
+    final_gradient_stops
+);
+impl_apply_palette!(
+    "unstable",
+    unstable::UnstableConfig,
+    unstable_color,
+    final_gradient_stops
+);
+impl_apply_palette!(
+    "vhstape",
+    vhstape::VhsTapeConfig,
+    glitch_line_colors,
+    glitch_wave_colors,
+    noise_colors,
+    final_gradient_stops
+);
+impl_apply_palette!(
+    "waves",
+    waves::WavesConfig,
+    wave_gradient_stops,
+    final_gradient_stops
+);
+impl_apply_palette!("wipe", wipe::WipeConfig, final_gradient_stops);
 
 #[cfg(test)]
 mod tests {
@@ -222,14 +464,51 @@ mod tests {
         assert!(super::build_named_effect("decrypt").is_some());
     }
 
+    #[cfg(feature = "decrypt")]
+    #[test]
+    fn named_effect_with_palette_builds() {
+        use crate::utils::palette::Palette;
+        let palette = Palette::from_hex_list("ff0000").unwrap();
+        assert!(super::build_named_effect_with_palette("decrypt", Some(&palette)).is_some());
+        assert!(super::build_named_effect_with_palette("decrypt", None).is_some());
+    }
+
     #[cfg(all(not(target_arch = "wasm32"), feature = "all-effects"))]
     #[test]
     fn default_configs_match_clap_subcommand_defaults() {
         use clap::Parser;
         for name in ALL_EFFECT_NAMES {
-            let via_clap = Cli::try_parse_from(["ttfx", *name]).unwrap().effect.unwrap();
+            let via_clap = Cli::try_parse_from(["ttfx", *name])
+                .unwrap()
+                .effect
+                .unwrap();
             let via_default = super::EffectCommand::with_defaults(name).unwrap();
-            assert_eq!(format!("{via_clap:?}"), format!("{via_default:?}"), "{name}");
+            assert_eq!(
+                format!("{via_clap:?}"),
+                format!("{via_default:?}"),
+                "{name}"
+            );
+        }
+    }
+
+    #[cfg(feature = "all-effects")]
+    #[test]
+    fn every_effect_applies_a_hex_palette() {
+        use crate::utils::graphics::parse_color;
+        use crate::utils::palette::Palette;
+        let palette = Palette::new(vec![
+            parse_color("ff0000").unwrap(),
+            parse_color("00ff00").unwrap(),
+        ])
+        .unwrap();
+        let skip = std::collections::HashSet::new();
+        for name in ALL_EFFECT_NAMES {
+            let original = format!("{:?}", super::EffectCommand::with_defaults(name).unwrap());
+            let mut cmd = super::EffectCommand::with_defaults(name).unwrap();
+            cmd.apply_palette(&palette, &skip);
+            let paletted = format!("{cmd:?}");
+            assert_ne!(original, paletted, "{name} ignored the palette");
+            let _effect = cmd.build_effect();
         }
     }
 }

--- a/src/effects/mod.rs
+++ b/src/effects/mod.rs
@@ -2,7 +2,9 @@
 //!
 //! One Cargo feature per effect. `all-effects` (the default) enables every
 //! row in `define_effects!`. A single-effect binary or wasm is
-//! `--no-default-features --features decrypt`.
+//! `--no-default-features --features decrypt`. Wasm builds effects from
+//! `Default` configs (`build_named_effect`) so clap stays out of that
+//! artifact.
 //!
 //! Adding an effect: a row here, an empty feature in Cargo.toml, and the name
 //! in the `all-effects` list. Keep those lists alphabetical by effect name.
@@ -58,6 +60,35 @@ macro_rules! define_effects {
                         EffectCommand::$variant(_) => $name,
                     )*
                 }
+            }
+
+            pub fn with_defaults(name: &str) -> Option<Self> {
+                match name {
+                    $(
+                        #[cfg(feature = $name)]
+                        $name => Some(EffectCommand::$variant($mod::$config::default())),
+                    )*
+                    _ => None,
+                }
+            }
+        }
+
+        pub fn catalog_entries() -> &'static [(&'static str, &'static str)] {
+            &[
+                $(
+                    #[cfg(feature = $name)]
+                    ($name, $about),
+                )*
+            ]
+        }
+
+        pub fn build_named_effect(name: &str) -> Option<Box<dyn Effect>> {
+            match name {
+                $(
+                    #[cfg(feature = $name)]
+                    $name => Some(Box::new($mod::$effect::new($mod::$config::default()))),
+                )*
+                _ => None,
             }
         }
 
@@ -166,5 +197,39 @@ mod tests {
             .effect
             .is_some());
         assert!(Cli::try_parse_from(["ttfx", "matrix"]).is_err());
+    }
+
+    #[test]
+    fn named_catalog_lists_enabled_effects() {
+        let names: Vec<&str> = super::catalog_entries()
+            .iter()
+            .map(|(name, _about)| *name)
+            .collect();
+        #[cfg(feature = "all-effects")]
+        assert_eq!(names, ALL_EFFECT_NAMES);
+        #[cfg(all(feature = "decrypt", not(feature = "all-effects")))]
+        assert_eq!(names, ["decrypt"]);
+    }
+
+    #[test]
+    fn unknown_effect_name_builds_nothing() {
+        assert!(super::build_named_effect("not-an-effect").is_none());
+    }
+
+    #[cfg(feature = "decrypt")]
+    #[test]
+    fn decrypt_builds_from_name() {
+        assert!(super::build_named_effect("decrypt").is_some());
+    }
+
+    #[cfg(all(not(target_arch = "wasm32"), feature = "all-effects"))]
+    #[test]
+    fn default_configs_match_clap_subcommand_defaults() {
+        use clap::Parser;
+        for name in ALL_EFFECT_NAMES {
+            let via_clap = Cli::try_parse_from(["ttfx", *name]).unwrap().effect.unwrap();
+            let via_default = super::EffectCommand::with_defaults(name).unwrap();
+            assert_eq!(format!("{via_clap:?}"), format!("{via_default:?}"), "{name}");
+        }
     }
 }

--- a/src/effects/mod.rs
+++ b/src/effects/mod.rs
@@ -1,209 +1,170 @@
 //! Static effect registry (replaces upstream pkgutil discovery).
-//! GENERATED structure — keep alphabetical by variant when adding effects.
+//!
+//! One Cargo feature per effect. `all-effects` (the default) enables every
+//! row in `define_effects!`. A single-effect binary or wasm is
+//! `--no-default-features --features decrypt`.
+//!
+//! Adding an effect: a row here, an empty feature in Cargo.toml, and the name
+//! in the `all-effects` list. Keep those lists alphabetical by effect name.
 
 pub mod common;
-pub mod beams;
-pub mod binarypath;
-pub mod blackhole;
-pub mod bouncyballs;
-pub mod bubbles;
-pub mod burn;
-pub mod colorshift;
-pub mod crumble;
-pub mod decrypt;
-pub mod errorcorrect;
-pub mod expand;
-pub mod fireworks;
-pub mod highlight;
-pub mod laseretch;
-pub mod matrix;
-pub mod middleout;
-pub mod orbittingvolley;
-pub mod overflow;
-pub mod pour;
-pub mod print_effect;
-pub mod rain;
-pub mod random_sequence;
-pub mod rings;
-pub mod scattered;
-pub mod slice;
-pub mod slide;
-pub mod smoke;
-pub mod spotlights;
-pub mod spray;
-pub mod swarm;
-pub mod sweep;
-pub mod synthgrid;
-pub mod thunderstorm;
-pub mod unstable;
-pub mod vhstape;
-pub mod waves;
-pub mod wipe;
 
 use clap::Subcommand;
 
 use crate::engine::effect::Effect;
 
-#[derive(Subcommand, Debug, Clone)]
-pub enum EffectCommand {
-    /// Create beams which travel over the canvas illuminating the characters behind them.
-    Beams(beams::BeamsConfig),
-    /// Binary representations of each character move towards the home coordinate of the character.
-    Binarypath(binarypath::BinaryPathConfig),
-    /// Characters are consumed by a black hole and explode outwards.
-    Blackhole(blackhole::BlackholeConfig),
-    /// Characters are bouncy balls falling from the top of the canvas.
-    Bouncyballs(bouncyballs::BouncyBallsConfig),
-    /// Characters are formed into bubbles that float down and pop.
-    Bubbles(bubbles::BubblesConfig),
-    /// Burns vertically in the canvas.
-    Burn(burn::BurnConfig),
-    /// Display a gradient that shifts colors across the terminal.
-    Colorshift(colorshift::ColorShiftConfig),
-    /// Characters lose color and crumble into dust, vacuumed up, and reformed.
-    Crumble(crumble::CrumbleConfig),
-    /// Display a movie style decryption effect.
-    Decrypt(decrypt::DecryptConfig),
-    /// Some characters start in the wrong position and are corrected in sequence.
-    Errorcorrect(errorcorrect::ErrorCorrectConfig),
-    /// Expands the text from a single point.
-    Expand(expand::ExpandConfig),
-    /// Characters launch and explode like fireworks and fall into place.
-    Fireworks(fireworks::FireworksConfig),
-    /// Run a specular highlight across the text.
-    Highlight(highlight::HighlightConfig),
-    /// A laser etches characters onto the terminal.
-    Laseretch(laseretch::LaserEtchConfig),
-    /// Matrix digital rain effect.
-    Matrix(matrix::MatrixConfig),
-    /// Text expands in a single row or column in the middle of the canvas then out.
-    Middleout(middleout::MiddleoutConfig),
-    /// Four launchers orbit the canvas firing volleys of characters inward to build the input text from the center out.
-    Orbittingvolley(orbittingvolley::OrbittingVolleyConfig),
-    /// Input text overflows and scrolls the terminal in a random order until eventually appearing ordered.
-    Overflow(overflow::OverflowConfig),
-    /// Pours the characters into position from the given direction.
-    Pour(pour::PourConfig),
-    /// Lines are printed one at a time following a print head. Print head performs line feed, carriage return.
-    Print(print_effect::PrintConfig),
-    /// Rain characters from the top of the canvas.
-    Rain(rain::RainConfig),
-    /// Prints the input data in a random sequence.
-    Randomsequence(random_sequence::RandomSequenceConfig),
-    /// Characters are dispersed and form into spinning rings.
-    Rings(rings::RingsConfig),
-    /// Text is scattered across the canvas and moves into position.
-    Scattered(scattered::ScatteredConfig),
-    /// Slices the input in half and slides it into place from opposite directions.
-    Slice(slice::SliceConfig),
-    /// Slide characters into view from outside the terminal.
-    Slide(slide::SlideConfig),
-    /// Smoke floods the canvas colorizing any characters it crosses.
-    Smoke(smoke::SmokeConfig),
-    /// Spotlights search the text area, illuminating characters, before converging in the center and expanding.
-    Spotlights(spotlights::SpotlightsConfig),
-    /// Draws the characters spawning at varying rates from a single point.
-    Spray(spray::SprayConfig),
-    /// Characters are grouped into swarms and move around the terminal before settling into position.
-    Swarm(swarm::SwarmConfig),
-    /// Sweep across the canvas to reveal uncolored text, reverse sweep to color the text.
-    Sweep(sweep::SweepConfig),
-    /// Create a grid which fills with characters dissolving into the final text.
-    Synthgrid(synthgrid::SynthGridConfig),
-    /// Create a thunderstorm in the terminal.
-    Thunderstorm(thunderstorm::ThunderstormConfig),
-    /// Spawn characters jumbled, explode them to the edge of the canvas, then reassemble them in the correct layout.
-    Unstable(unstable::UnstableConfig),
-    /// Lines of characters glitch left and right and lose detail like an old VHS tape.
-    Vhstape(vhstape::VhsTapeConfig),
-    /// Waves travel across the terminal leaving behind the characters.
-    Waves(waves::WavesConfig),
-    /// Wipes the text across the terminal to reveal characters.
-    Wipe(wipe::WipeConfig),
+macro_rules! define_effects {
+    ($(
+        $name:literal,
+        $mod:ident,
+        $variant:ident,
+        $config:ident,
+        $effect:ident,
+        $about:literal
+    );* $(;)?) => {
+        $(
+            #[cfg(feature = $name)]
+            pub mod $mod;
+        )*
+
+        #[cfg(not(any($(feature = $name),*)))]
+        compile_error!(
+            "no effects enabled; build with default features or --no-default-features --features <effect>"
+        );
+
+        #[derive(Subcommand, Debug, Clone)]
+        pub enum EffectCommand {
+            $(
+                #[cfg(feature = $name)]
+                #[doc = $about]
+                $variant($mod::$config),
+            )*
+        }
+
+        impl EffectCommand {
+            pub fn build_effect(&self) -> Box<dyn Effect> {
+                match self {
+                    $(
+                        #[cfg(feature = $name)]
+                        EffectCommand::$variant(config) => Box::new($mod::$effect::new(config.clone())),
+                    )*
+                }
+            }
+
+            pub fn name(&self) -> &'static str {
+                match self {
+                    $(
+                        #[cfg(feature = $name)]
+                        EffectCommand::$variant(_) => $name,
+                    )*
+                }
+            }
+        }
+
+        #[cfg(test)]
+        const ALL_EFFECT_NAMES: &[&str] = &[$($name),*];
+    };
 }
 
-impl EffectCommand {
-    pub fn build_effect(&self) -> Box<dyn Effect> {
-        match self {
-            EffectCommand::Beams(config) => Box::new(beams::Beams::new(config.clone())),
-            EffectCommand::Binarypath(config) => Box::new(binarypath::BinaryPath::new(config.clone())),
-            EffectCommand::Blackhole(config) => Box::new(blackhole::Blackhole::new(config.clone())),
-            EffectCommand::Bouncyballs(config) => Box::new(bouncyballs::BouncyBalls::new(config.clone())),
-            EffectCommand::Bubbles(config) => Box::new(bubbles::Bubbles::new(config.clone())),
-            EffectCommand::Burn(config) => Box::new(burn::Burn::new(config.clone())),
-            EffectCommand::Colorshift(config) => Box::new(colorshift::ColorShift::new(config.clone())),
-            EffectCommand::Crumble(config) => Box::new(crumble::Crumble::new(config.clone())),
-            EffectCommand::Decrypt(config) => Box::new(decrypt::Decrypt::new(config.clone())),
-            EffectCommand::Errorcorrect(config) => Box::new(errorcorrect::ErrorCorrect::new(config.clone())),
-            EffectCommand::Expand(config) => Box::new(expand::Expand::new(config.clone())),
-            EffectCommand::Fireworks(config) => Box::new(fireworks::Fireworks::new(config.clone())),
-            EffectCommand::Highlight(config) => Box::new(highlight::Highlight::new(config.clone())),
-            EffectCommand::Laseretch(config) => Box::new(laseretch::LaserEtch::new(config.clone())),
-            EffectCommand::Matrix(config) => Box::new(matrix::Matrix::new(config.clone())),
-            EffectCommand::Middleout(config) => Box::new(middleout::Middleout::new(config.clone())),
-            EffectCommand::Orbittingvolley(config) => Box::new(orbittingvolley::OrbittingVolley::new(config.clone())),
-            EffectCommand::Overflow(config) => Box::new(overflow::Overflow::new(config.clone())),
-            EffectCommand::Pour(config) => Box::new(pour::Pour::new(config.clone())),
-            EffectCommand::Print(config) => Box::new(print_effect::Print::new(config.clone())),
-            EffectCommand::Rain(config) => Box::new(rain::Rain::new(config.clone())),
-            EffectCommand::Randomsequence(config) => Box::new(random_sequence::RandomSequence::new(config.clone())),
-            EffectCommand::Rings(config) => Box::new(rings::Rings::new(config.clone())),
-            EffectCommand::Scattered(config) => Box::new(scattered::Scattered::new(config.clone())),
-            EffectCommand::Slice(config) => Box::new(slice::Slice::new(config.clone())),
-            EffectCommand::Slide(config) => Box::new(slide::Slide::new(config.clone())),
-            EffectCommand::Smoke(config) => Box::new(smoke::Smoke::new(config.clone())),
-            EffectCommand::Spotlights(config) => Box::new(spotlights::Spotlights::new(config.clone())),
-            EffectCommand::Spray(config) => Box::new(spray::Spray::new(config.clone())),
-            EffectCommand::Swarm(config) => Box::new(swarm::Swarm::new(config.clone())),
-            EffectCommand::Sweep(config) => Box::new(sweep::Sweep::new(config.clone())),
-            EffectCommand::Synthgrid(config) => Box::new(synthgrid::SynthGrid::new(config.clone())),
-            EffectCommand::Thunderstorm(config) => Box::new(thunderstorm::Thunderstorm::new(config.clone())),
-            EffectCommand::Unstable(config) => Box::new(unstable::Unstable::new(config.clone())),
-            EffectCommand::Vhstape(config) => Box::new(vhstape::VhsTape::new(config.clone())),
-            EffectCommand::Waves(config) => Box::new(waves::Waves::new(config.clone())),
-            EffectCommand::Wipe(config) => Box::new(wipe::Wipe::new(config.clone())),
+define_effects! {
+    "beams", beams, Beams, BeamsConfig, Beams, "Create beams which travel over the canvas illuminating the characters behind them.";
+    "binarypath", binarypath, Binarypath, BinaryPathConfig, BinaryPath, "Binary representations of each character move towards the home coordinate of the character.";
+    "blackhole", blackhole, Blackhole, BlackholeConfig, Blackhole, "Characters are consumed by a black hole and explode outwards.";
+    "bouncyballs", bouncyballs, Bouncyballs, BouncyBallsConfig, BouncyBalls, "Characters are bouncy balls falling from the top of the canvas.";
+    "bubbles", bubbles, Bubbles, BubblesConfig, Bubbles, "Characters are formed into bubbles that float down and pop.";
+    "burn", burn, Burn, BurnConfig, Burn, "Burns vertically in the canvas.";
+    "colorshift", colorshift, Colorshift, ColorShiftConfig, ColorShift, "Display a gradient that shifts colors across the terminal.";
+    "crumble", crumble, Crumble, CrumbleConfig, Crumble, "Characters lose color and crumble into dust, vacuumed up, and reformed.";
+    "decrypt", decrypt, Decrypt, DecryptConfig, Decrypt, "Display a movie style decryption effect.";
+    "errorcorrect", errorcorrect, Errorcorrect, ErrorCorrectConfig, ErrorCorrect, "Some characters start in the wrong position and are corrected in sequence.";
+    "expand", expand, Expand, ExpandConfig, Expand, "Expands the text from a single point.";
+    "fireworks", fireworks, Fireworks, FireworksConfig, Fireworks, "Characters launch and explode like fireworks and fall into place.";
+    "highlight", highlight, Highlight, HighlightConfig, Highlight, "Run a specular highlight across the text.";
+    "laseretch", laseretch, Laseretch, LaserEtchConfig, LaserEtch, "A laser etches characters onto the terminal.";
+    "matrix", matrix, Matrix, MatrixConfig, Matrix, "Matrix digital rain effect.";
+    "middleout", middleout, Middleout, MiddleoutConfig, Middleout, "Text expands in a single row or column in the middle of the canvas then out.";
+    "orbittingvolley", orbittingvolley, Orbittingvolley, OrbittingVolleyConfig, OrbittingVolley, "Four launchers orbit the canvas firing volleys of characters inward to build the input text from the center out.";
+    "overflow", overflow, Overflow, OverflowConfig, Overflow, "Input text overflows and scrolls the terminal in a random order until eventually appearing ordered.";
+    "pour", pour, Pour, PourConfig, Pour, "Pours the characters into position from the given direction.";
+    "print", print_effect, Print, PrintConfig, Print, "Lines are printed one at a time following a print head. Print head performs line feed, carriage return.";
+    "rain", rain, Rain, RainConfig, Rain, "Rain characters from the top of the canvas.";
+    "randomsequence", random_sequence, Randomsequence, RandomSequenceConfig, RandomSequence, "Prints the input data in a random sequence.";
+    "rings", rings, Rings, RingsConfig, Rings, "Characters are dispersed and form into spinning rings.";
+    "scattered", scattered, Scattered, ScatteredConfig, Scattered, "Text is scattered across the canvas and moves into position.";
+    "slice", slice, Slice, SliceConfig, Slice, "Slices the input in half and slides it into place from opposite directions.";
+    "slide", slide, Slide, SlideConfig, Slide, "Slide characters into view from outside the terminal.";
+    "smoke", smoke, Smoke, SmokeConfig, Smoke, "Smoke floods the canvas colorizing any characters it crosses.";
+    "spotlights", spotlights, Spotlights, SpotlightsConfig, Spotlights, "Spotlights search the text area, illuminating characters, before converging in the center and expanding.";
+    "spray", spray, Spray, SprayConfig, Spray, "Draws the characters spawning at varying rates from a single point.";
+    "swarm", swarm, Swarm, SwarmConfig, Swarm, "Characters are grouped into swarms and move around the terminal before settling into position.";
+    "sweep", sweep, Sweep, SweepConfig, Sweep, "Sweep across the canvas to reveal uncolored text, reverse sweep to color the text.";
+    "synthgrid", synthgrid, Synthgrid, SynthGridConfig, SynthGrid, "Create a grid which fills with characters dissolving into the final text.";
+    "thunderstorm", thunderstorm, Thunderstorm, ThunderstormConfig, Thunderstorm, "Create a thunderstorm in the terminal.";
+    "unstable", unstable, Unstable, UnstableConfig, Unstable, "Spawn characters jumbled, explode them to the edge of the canvas, then reassemble them in the correct layout.";
+    "vhstape", vhstape, Vhstape, VhsTapeConfig, VhsTape, "Lines of characters glitch left and right and lose detail like an old VHS tape.";
+    "waves", waves, Waves, WavesConfig, Waves, "Waves travel across the terminal leaving behind the characters.";
+    "wipe", wipe, Wipe, WipeConfig, Wipe, "Wipes the text across the terminal to reveal characters.";
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::CommandFactory;
+    #[cfg(all(feature = "decrypt", not(feature = "all-effects")))]
+    use clap::Parser;
+
+    use super::ALL_EFFECT_NAMES;
+    use crate::cli::Cli;
+
+    fn catalog_names() -> Vec<String> {
+        Cli::command()
+            .get_subcommands()
+            .map(|cmd| cmd.get_name().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn effect_inventory_is_alphabetical() {
+        let mut sorted = ALL_EFFECT_NAMES.to_vec();
+        sorted.sort_unstable();
+        assert_eq!(ALL_EFFECT_NAMES, sorted.as_slice());
+    }
+
+    #[test]
+    fn cargo_toml_declares_every_effect_feature() {
+        let cargo = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml"));
+        for name in ALL_EFFECT_NAMES {
+            let feature = format!("{name} = []");
+            let umbrella = format!("    \"{name}\",");
+            assert!(cargo.contains(&feature), "Cargo.toml missing `{feature}`");
+            assert!(cargo.contains(&umbrella), "all-effects is missing `{name}`");
         }
     }
 
-    pub fn name(&self) -> &'static str {
-        match self {
-            EffectCommand::Beams(_) => "beams",
-            EffectCommand::Binarypath(_) => "binarypath",
-            EffectCommand::Blackhole(_) => "blackhole",
-            EffectCommand::Bouncyballs(_) => "bouncyballs",
-            EffectCommand::Bubbles(_) => "bubbles",
-            EffectCommand::Burn(_) => "burn",
-            EffectCommand::Colorshift(_) => "colorshift",
-            EffectCommand::Crumble(_) => "crumble",
-            EffectCommand::Decrypt(_) => "decrypt",
-            EffectCommand::Errorcorrect(_) => "errorcorrect",
-            EffectCommand::Expand(_) => "expand",
-            EffectCommand::Fireworks(_) => "fireworks",
-            EffectCommand::Highlight(_) => "highlight",
-            EffectCommand::Laseretch(_) => "laseretch",
-            EffectCommand::Matrix(_) => "matrix",
-            EffectCommand::Middleout(_) => "middleout",
-            EffectCommand::Orbittingvolley(_) => "orbittingvolley",
-            EffectCommand::Overflow(_) => "overflow",
-            EffectCommand::Pour(_) => "pour",
-            EffectCommand::Print(_) => "print",
-            EffectCommand::Rain(_) => "rain",
-            EffectCommand::Randomsequence(_) => "randomsequence",
-            EffectCommand::Rings(_) => "rings",
-            EffectCommand::Scattered(_) => "scattered",
-            EffectCommand::Slice(_) => "slice",
-            EffectCommand::Slide(_) => "slide",
-            EffectCommand::Smoke(_) => "smoke",
-            EffectCommand::Spotlights(_) => "spotlights",
-            EffectCommand::Spray(_) => "spray",
-            EffectCommand::Swarm(_) => "swarm",
-            EffectCommand::Sweep(_) => "sweep",
-            EffectCommand::Synthgrid(_) => "synthgrid",
-            EffectCommand::Thunderstorm(_) => "thunderstorm",
-            EffectCommand::Unstable(_) => "unstable",
-            EffectCommand::Vhstape(_) => "vhstape",
-            EffectCommand::Waves(_) => "waves",
-            EffectCommand::Wipe(_) => "wipe",
-        }
+    #[cfg(feature = "all-effects")]
+    #[test]
+    fn default_registry_includes_every_effect() {
+        assert_eq!(catalog_names(), ALL_EFFECT_NAMES);
+    }
+
+    #[cfg(feature = "decrypt")]
+    #[test]
+    fn decrypt_about_is_preserved() {
+        let about = Cli::command()
+            .get_subcommands()
+            .find(|cmd| cmd.get_name() == "decrypt")
+            .and_then(|cmd| cmd.get_about().map(|s| s.to_string()))
+            .unwrap_or_default();
+        assert!(about.contains("movie style decryption"), "{about:?}");
+    }
+
+    #[cfg(all(feature = "decrypt", not(feature = "all-effects")))]
+    #[test]
+    fn single_effect_build_exposes_only_decrypt() {
+        assert_eq!(catalog_names(), ["decrypt"]);
+        assert!(Cli::try_parse_from(["ttfx", "decrypt"])
+            .unwrap()
+            .effect
+            .is_some());
+        assert!(Cli::try_parse_from(["ttfx", "matrix"]).is_err());
     }
 }

--- a/src/effects/orbittingvolley.rs
+++ b/src/effects/orbittingvolley.rs
@@ -8,7 +8,6 @@ use std::collections::HashMap;
 
 use clap::Args;
 
-use crate::cli::parse_color;
 use crate::effects::common::{
     parse_easing, parse_gradient_direction, parse_gradient_steps, parse_non_negative_int, parse_non_negative_ratio,
     parse_positive_float, parse_symbol,
@@ -22,7 +21,7 @@ use crate::engine::events::{CallerKey, EffectCallback, Event, EventAction};
 use crate::engine::terminal::{CharacterFilter, CharacterGroup, CharacterSort};
 use crate::utils::easing::Easing;
 use crate::utils::geometry::Coord;
-use crate::utils::graphics::{Color, ColorPair, CoordColorMap, Gradient, GradientDirection};
+use crate::utils::graphics::{parse_color, Color, ColorPair, CoordColorMap, Gradient, GradientDirection};
 
 #[derive(Args, Debug, Clone)]
 pub struct OrbittingVolleyConfig {
@@ -75,6 +74,25 @@ pub struct OrbittingVolleyConfig {
     /// Direction of the final gradient.
     #[arg(long = "final-gradient-direction", default_value = "radial", value_parser = parse_gradient_direction)]
     pub final_gradient_direction: GradientDirection,
+}
+
+impl Default for OrbittingVolleyConfig {
+    fn default() -> Self {
+        Self {
+            top_launcher_symbol: parse_symbol("█").expect("default top_launcher_symbol"),
+            right_launcher_symbol: parse_symbol("█").expect("default right_launcher_symbol"),
+            bottom_launcher_symbol: parse_symbol("█").expect("default bottom_launcher_symbol"),
+            left_launcher_symbol: parse_symbol("█").expect("default left_launcher_symbol"),
+            launcher_movement_speed: 0.8,
+            character_movement_speed: 1.5,
+            volley_size: 0.03,
+            launch_delay: 30,
+            character_easing: parse_easing("out_sine").expect("default character_easing"),
+            final_gradient_stops: ["FFA15C", "44D492"].into_iter().map(|v| parse_color(v).expect("default final_gradient_stops")).collect(),
+            final_gradient_steps: ["12"].into_iter().map(|v| parse_gradient_steps(v).expect("default final_gradient_steps")).collect(),
+            final_gradient_direction: parse_gradient_direction("radial").expect("default final_gradient_direction"),
+        }
+    }
 }
 
 /// OrbittingVolleyIterator.Launcher.

--- a/src/effects/overflow.rs
+++ b/src/effects/overflow.rs
@@ -4,7 +4,6 @@ use std::collections::{HashMap, VecDeque};
 
 use clap::Args;
 
-use crate::cli::parse_color;
 use crate::effects::common::{
     parse_gradient_direction, parse_gradient_steps, parse_positive_int, parse_positive_int_range,
 };
@@ -16,7 +15,7 @@ use crate::engine::error::EngineError;
 use crate::engine::events::EffectCallback;
 use crate::engine::terminal::{CharacterFilter, CharacterGroup};
 use crate::utils::geometry::Coord;
-use crate::utils::graphics::{Color, ColorPair, Gradient, GradientDirection};
+use crate::utils::graphics::{parse_color, Color, ColorPair, Gradient, GradientDirection};
 use crate::utils::pycompat::floor_div;
 
 #[derive(Args, Debug, Clone)]
@@ -47,6 +46,19 @@ pub struct OverflowConfig {
     /// Direction of the final gradient.
     #[arg(long = "final-gradient-direction", default_value = "vertical", value_parser = parse_gradient_direction)]
     pub final_gradient_direction: GradientDirection,
+}
+
+impl Default for OverflowConfig {
+    fn default() -> Self {
+        Self {
+            overflow_gradient_stops: ["f2ebc0", "8dbfb3", "f2ebc0"].into_iter().map(|v| parse_color(v).expect("default overflow_gradient_stops")).collect(),
+            overflow_cycles_range: parse_positive_int_range("2-4").expect("default overflow_cycles_range"),
+            overflow_speed: 3,
+            final_gradient_stops: ["8A008A", "00D1FF", "FFFFFF"].into_iter().map(|v| parse_color(v).expect("default final_gradient_stops")).collect(),
+            final_gradient_steps: ["12"].into_iter().map(|v| parse_gradient_steps(v).expect("default final_gradient_steps")).collect(),
+            final_gradient_direction: parse_gradient_direction("vertical").expect("default final_gradient_direction"),
+        }
+    }
 }
 
 /// OverflowIterator.Row.

--- a/src/effects/pour.rs
+++ b/src/effects/pour.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 
 use clap::Args;
 
-use crate::cli::parse_color;
 use crate::effects::common::{
     parse_easing, parse_gradient_direction, parse_gradient_steps, parse_non_negative_int, parse_positive_float_range,
     parse_positive_int,
@@ -18,7 +17,7 @@ use crate::engine::events::EffectCallback;
 use crate::engine::terminal::{CharacterFilter, CharacterGroup, CharacterSort};
 use crate::utils::easing::Easing;
 use crate::utils::geometry::Coord;
-use crate::utils::graphics::{Color, ColorPair, Gradient, GradientDirection};
+use crate::utils::graphics::{parse_color, Color, ColorPair, Gradient, GradientDirection};
 
 /// PourIterator.PourDirection.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -82,6 +81,23 @@ pub struct PourConfig {
     /// Easing function to use for character movement.
     #[arg(long = "movement-easing", default_value = "in_quad", value_parser = parse_easing)]
     pub movement_easing: Easing,
+}
+
+impl Default for PourConfig {
+    fn default() -> Self {
+        Self {
+            pour_direction: parse_pour_direction("down").expect("default pour_direction"),
+            pour_speed: 2,
+            movement_speed_range: parse_positive_float_range("0.4-0.6").expect("default movement_speed_range"),
+            gap: 1,
+            starting_color: parse_color("ffffff").expect("default starting_color"),
+            final_gradient_stops: ["8A008A", "00D1FF", "FFFFFF"].into_iter().map(|v| parse_color(v).expect("default final_gradient_stops")).collect(),
+            final_gradient_steps: ["12"].into_iter().map(|v| parse_gradient_steps(v).expect("default final_gradient_steps")).collect(),
+            final_gradient_frames: 6,
+            final_gradient_direction: parse_gradient_direction("vertical").expect("default final_gradient_direction"),
+            movement_easing: parse_easing("in_quad").expect("default movement_easing"),
+        }
+    }
 }
 
 pub struct Pour {

--- a/src/effects/print_effect.rs
+++ b/src/effects/print_effect.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 
 use clap::Args;
 
-use crate::cli::parse_color;
 use crate::effects::common::{
     parse_easing, parse_gradient_direction, parse_gradient_steps, parse_positive_float, parse_positive_int,
 };
@@ -17,7 +16,7 @@ use crate::engine::events::{CallerKey, EffectCallback, Event, EventAction};
 use crate::engine::terminal::{CharacterFilter, CharacterGroup};
 use crate::utils::easing::Easing;
 use crate::utils::geometry::Coord;
-use crate::utils::graphics::{Color, ColorPair, Gradient, GradientDirection};
+use crate::utils::graphics::{parse_color, Color, ColorPair, Gradient, GradientDirection};
 
 #[derive(Args, Debug, Clone)]
 pub struct PrintConfig {
@@ -46,6 +45,19 @@ pub struct PrintConfig {
     /// Direction of the final gradient.
     #[arg(long = "final-gradient-direction", default_value = "diagonal", value_parser = parse_gradient_direction)]
     pub final_gradient_direction: GradientDirection,
+}
+
+impl Default for PrintConfig {
+    fn default() -> Self {
+        Self {
+            print_head_return_speed: 1.5,
+            print_speed: 2,
+            print_head_easing: parse_easing("in_out_quad").expect("default print_head_easing"),
+            final_gradient_stops: ["02b8bd", "c1f0e3", "00ffa0"].into_iter().map(|v| parse_color(v).expect("default final_gradient_stops")).collect(),
+            final_gradient_steps: ["12"].into_iter().map(|v| parse_gradient_steps(v).expect("default final_gradient_steps")).collect(),
+            final_gradient_direction: parse_gradient_direction("diagonal").expect("default final_gradient_direction"),
+        }
+    }
 }
 
 /// PrintIterator.Row (plain struct over CharIds; scene/coord setup happens in

--- a/src/effects/rain.rs
+++ b/src/effects/rain.rs
@@ -4,7 +4,6 @@ use std::collections::{BTreeMap, HashMap};
 
 use clap::Args;
 
-use crate::cli::parse_color;
 use crate::effects::common::{
     parse_easing, parse_gradient_direction, parse_gradient_steps, parse_positive_float_range, parse_symbol,
 };
@@ -17,7 +16,7 @@ use crate::engine::events::{CallerKey, EffectCallback, Event, EventAction};
 use crate::engine::terminal::{CharacterFilter, CharacterSort};
 use crate::utils::easing::Easing;
 use crate::utils::geometry::Coord;
-use crate::utils::graphics::{Color, ColorPair, Gradient, GradientDirection};
+use crate::utils::graphics::{parse_color, Color, ColorPair, Gradient, GradientDirection};
 
 #[derive(Args, Debug, Clone)]
 pub struct RainConfig {
@@ -52,6 +51,20 @@ pub struct RainConfig {
     /// Easing function to use for character movement.
     #[arg(long = "movement-easing", default_value = "in_quart", value_parser = parse_easing)]
     pub movement_easing: Easing,
+}
+
+impl Default for RainConfig {
+    fn default() -> Self {
+        Self {
+            rain_colors: ["00315C", "004C8F", "0075DB", "3F91D9", "78B9F2", "9AC8F5", "B8D8F8", "E3EFFC"].into_iter().map(|v| parse_color(v).expect("default rain_colors")).collect(),
+            movement_speed: parse_positive_float_range("0.33-0.57").expect("default movement_speed"),
+            rain_symbols: ["o", ".", ",", "*", "|"].into_iter().map(|v| parse_symbol(v).expect("default rain_symbols")).collect(),
+            final_gradient_stops: ["488bff", "b2e7de", "57eaf7"].into_iter().map(|v| parse_color(v).expect("default final_gradient_stops")).collect(),
+            final_gradient_steps: ["12"].into_iter().map(|v| parse_gradient_steps(v).expect("default final_gradient_steps")).collect(),
+            final_gradient_direction: parse_gradient_direction("diagonal").expect("default final_gradient_direction"),
+            movement_easing: parse_easing("in_quart").expect("default movement_easing"),
+        }
+    }
 }
 
 pub struct Rain {

--- a/src/effects/random_sequence.rs
+++ b/src/effects/random_sequence.rs
@@ -12,9 +12,8 @@ use crate::engine::effect::Effect;
 use crate::engine::error::EngineError;
 use crate::engine::events::EffectCallback;
 use crate::engine::terminal::{CharacterFilter, CharacterSort};
-use crate::utils::graphics::{Color, ColorPair, Gradient, GradientDirection};
+use crate::utils::graphics::{parse_color, Color, ColorPair, Gradient, GradientDirection};
 
-use crate::cli::parse_color;
 
 #[derive(Args, Debug, Clone)]
 pub struct RandomSequenceConfig {
@@ -39,6 +38,18 @@ pub struct RandomSequenceConfig {
     /// Direction of the final gradient.
     #[arg(long = "final-gradient-direction", default_value = "vertical", value_parser = parse_gradient_direction)]
     pub final_gradient_direction: GradientDirection,
+}
+
+impl Default for RandomSequenceConfig {
+    fn default() -> Self {
+        Self {
+            speed: 0.007,
+            final_gradient_stops: ["8A008A", "00D1FF", "FFFFFF"].into_iter().map(|v| parse_color(v).expect("default final_gradient_stops")).collect(),
+            final_gradient_steps: ["12"].into_iter().map(|v| parse_gradient_steps(v).expect("default final_gradient_steps")).collect(),
+            final_gradient_frames: 8,
+            final_gradient_direction: parse_gradient_direction("vertical").expect("default final_gradient_direction"),
+        }
+    }
 }
 
 pub struct RandomSequence {

--- a/src/effects/rings.rs
+++ b/src/effects/rings.rs
@@ -9,7 +9,6 @@ use std::collections::{HashMap, HashSet};
 
 use clap::Args;
 
-use crate::cli::parse_color;
 use crate::effects::common::{
     parse_gradient_direction, parse_gradient_steps, parse_positive_float, parse_positive_float_range,
     parse_positive_int,
@@ -23,7 +22,7 @@ use crate::engine::events::{CallerKey, EffectCallback, Event, EventAction};
 use crate::engine::terminal::{CharacterFilter, CharacterSort};
 use crate::utils::easing::Easing;
 use crate::utils::geometry::{self, Coord};
-use crate::utils::graphics::{Color, ColorPair, Gradient, GradientDirection};
+use crate::utils::graphics::{parse_color, Color, ColorPair, Gradient, GradientDirection};
 use crate::utils::pycompat::round_half_even;
 
 /// Callback id: terminal.set_character_visibility(character, False).
@@ -69,6 +68,22 @@ pub struct RingsConfig {
     /// Direction of the final gradient.
     #[arg(long = "final-gradient-direction", default_value = "vertical", value_parser = parse_gradient_direction)]
     pub final_gradient_direction: GradientDirection,
+}
+
+impl Default for RingsConfig {
+    fn default() -> Self {
+        Self {
+            ring_colors: ["ab48ff", "e7b2b2", "fffebd"].into_iter().map(|v| parse_color(v).expect("default ring_colors")).collect(),
+            ring_gap: 0.1,
+            spin_duration: 200,
+            spin_speed: parse_positive_float_range("0.25-1.0").expect("default spin_speed"),
+            disperse_duration: 200,
+            spin_disperse_cycles: 3,
+            final_gradient_stops: ["ab48ff", "e7b2b2", "fffebd"].into_iter().map(|v| parse_color(v).expect("default final_gradient_stops")).collect(),
+            final_gradient_steps: ["12"].into_iter().map(|v| parse_gradient_steps(v).expect("default final_gradient_steps")).collect(),
+            final_gradient_direction: parse_gradient_direction("vertical").expect("default final_gradient_direction"),
+        }
+    }
 }
 
 /// RingsIterator.Ring.

--- a/src/effects/scattered.rs
+++ b/src/effects/scattered.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 
 use clap::Args;
 
-use crate::cli::parse_color;
 use crate::effects::common::{parse_easing, parse_gradient_direction, parse_gradient_steps, parse_positive_float};
 use crate::engine::animation::{ExistingColorHandling, SyncMetric, VisualParams};
 use crate::engine::character::CharId;
@@ -15,7 +14,7 @@ use crate::engine::events::{CallerKey, EffectCallback, Event, EventAction};
 use crate::engine::terminal::{CharacterFilter, CharacterSort};
 use crate::utils::easing::Easing;
 use crate::utils::geometry::Coord;
-use crate::utils::graphics::{Color, ColorPair, Gradient, GradientDirection};
+use crate::utils::graphics::{parse_color, Color, ColorPair, Gradient, GradientDirection};
 
 #[derive(Args, Debug, Clone)]
 pub struct ScatteredConfig {
@@ -44,6 +43,19 @@ pub struct ScatteredConfig {
     /// Direction of the final gradient.
     #[arg(long = "final-gradient-direction", default_value = "vertical", value_parser = parse_gradient_direction)]
     pub final_gradient_direction: GradientDirection,
+}
+
+impl Default for ScatteredConfig {
+    fn default() -> Self {
+        Self {
+            movement_speed: 0.5,
+            movement_easing: parse_easing("in_out_back").expect("default movement_easing"),
+            final_gradient_stops: ["ff9048", "ab9dff", "bdffea"].into_iter().map(|v| parse_color(v).expect("default final_gradient_stops")).collect(),
+            final_gradient_steps: ["12"].into_iter().map(|v| parse_gradient_steps(v).expect("default final_gradient_steps")).collect(),
+            final_gradient_frames: 9,
+            final_gradient_direction: parse_gradient_direction("vertical").expect("default final_gradient_direction"),
+        }
+    }
 }
 
 pub struct Scattered {

--- a/src/effects/slice.rs
+++ b/src/effects/slice.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 
 use clap::Args;
 
-use crate::cli::parse_color;
 use crate::effects::common::{parse_easing, parse_gradient_direction, parse_gradient_steps, parse_positive_float};
 use crate::engine::animation::ExistingColorHandling;
 use crate::engine::character::CharId;
@@ -15,7 +14,7 @@ use crate::engine::events::EffectCallback;
 use crate::engine::terminal::{CharacterFilter, CharacterGroup, CharacterSort};
 use crate::utils::easing::Easing;
 use crate::utils::geometry::Coord;
-use crate::utils::graphics::{Color, ColorPair, Gradient, GradientDirection};
+use crate::utils::graphics::{parse_color, Color, ColorPair, Gradient, GradientDirection};
 
 #[derive(Args, Debug, Clone)]
 pub struct SliceConfig {
@@ -45,6 +44,19 @@ pub struct SliceConfig {
     /// Direction of the final gradient.
     #[arg(long = "final-gradient-direction", default_value = "diagonal", value_parser = parse_gradient_direction)]
     pub final_gradient_direction: GradientDirection,
+}
+
+impl Default for SliceConfig {
+    fn default() -> Self {
+        Self {
+            slice_direction: "vertical".to_string(),
+            movement_speed: 0.25,
+            movement_easing: parse_easing("in_out_expo").expect("default movement_easing"),
+            final_gradient_stops: ["8A008A", "00D1FF", "FFFFFF"].into_iter().map(|v| parse_color(v).expect("default final_gradient_stops")).collect(),
+            final_gradient_steps: ["12"].into_iter().map(|v| parse_gradient_steps(v).expect("default final_gradient_steps")).collect(),
+            final_gradient_direction: parse_gradient_direction("diagonal").expect("default final_gradient_direction"),
+        }
+    }
 }
 
 pub struct Slice {

--- a/src/effects/slide.rs
+++ b/src/effects/slide.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 
 use clap::Args;
 
-use crate::cli::parse_color;
 use crate::effects::common::{
     parse_easing, parse_gradient_direction, parse_gradient_steps, parse_non_negative_int, parse_positive_float,
 };
@@ -17,7 +16,7 @@ use crate::engine::events::EffectCallback;
 use crate::engine::terminal::{CharacterFilter, CharacterGroup, CharacterSort};
 use crate::utils::easing::Easing;
 use crate::utils::geometry::Coord;
-use crate::utils::graphics::{Color, ColorPair, Gradient, GradientDirection};
+use crate::utils::graphics::{parse_color, Color, ColorPair, Gradient, GradientDirection};
 
 /// typing.Literal["row", "column", "diagonal"].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -79,6 +78,23 @@ pub struct SlideConfig {
     /// Direction of the gradient.
     #[arg(long = "final-gradient-direction", default_value = "vertical", value_parser = parse_gradient_direction)]
     pub final_gradient_direction: GradientDirection,
+}
+
+impl Default for SlideConfig {
+    fn default() -> Self {
+        Self {
+            movement_speed: 0.8,
+            grouping: parse_slide_grouping("row").expect("default grouping"),
+            gap: 2,
+            reverse_direction: false,
+            merge: false,
+            movement_easing: parse_easing("in_out_quad").expect("default movement_easing"),
+            final_gradient_stops: ["833ab4", "fd1d1d", "fcb045"].into_iter().map(|v| parse_color(v).expect("default final_gradient_stops")).collect(),
+            final_gradient_steps: ["12"].into_iter().map(|v| parse_gradient_steps(v).expect("default final_gradient_steps")).collect(),
+            final_gradient_frames: 6,
+            final_gradient_direction: parse_gradient_direction("vertical").expect("default final_gradient_direction"),
+        }
+    }
 }
 
 pub struct Slide {

--- a/src/effects/smoke.rs
+++ b/src/effects/smoke.rs
@@ -12,7 +12,6 @@ use std::collections::HashMap;
 
 use clap::Args;
 
-use crate::cli::parse_color;
 use crate::effects::common::{parse_gradient_direction, parse_gradient_steps, parse_symbol};
 use crate::engine::animation::{ExistingColorHandling, VisualParams};
 use crate::engine::character::CharId;
@@ -21,7 +20,7 @@ use crate::engine::effect::Effect;
 use crate::engine::error::EngineError;
 use crate::engine::events::{CallerKey, EffectCallback, Event, EventAction};
 use crate::engine::terminal::{CharacterFilter, CharacterSort};
-use crate::utils::graphics::{Color, ColorPair, Gradient, GradientDirection};
+use crate::utils::graphics::{parse_color, Color, ColorPair, Gradient, GradientDirection};
 use crate::utils::spanning_tree::{BreadthFirst, PrimsWeighted};
 
 #[derive(Args, Debug, Clone)]
@@ -57,6 +56,20 @@ pub struct SmokeConfig {
     /// Direction of the final gradient.
     #[arg(long = "final-gradient-direction", default_value = "vertical", value_parser = parse_gradient_direction)]
     pub final_gradient_direction: GradientDirection,
+}
+
+impl Default for SmokeConfig {
+    fn default() -> Self {
+        Self {
+            starting_color: parse_color("7A7A7A").expect("default starting_color"),
+            smoke_symbols: ["░", "▒", "▓", "▒", "░"].into_iter().map(|v| parse_symbol(v).expect("default smoke_symbols")).collect(),
+            smoke_gradient_stops: ["242424", "FFFFFF"].into_iter().map(|v| parse_color(v).expect("default smoke_gradient_stops")).collect(),
+            use_whole_canvas: false,
+            final_gradient_stops: ["8A008A", "00D1FF", "FFFFFF"].into_iter().map(|v| parse_color(v).expect("default final_gradient_stops")).collect(),
+            final_gradient_steps: ["12"].into_iter().map(|v| parse_gradient_steps(v).expect("default final_gradient_steps")).collect(),
+            final_gradient_direction: parse_gradient_direction("vertical").expect("default final_gradient_direction"),
+        }
+    }
 }
 
 pub struct Smoke {

--- a/src/effects/spotlights.rs
+++ b/src/effects/spotlights.rs
@@ -4,7 +4,6 @@ use std::collections::{BTreeSet, HashMap};
 
 use clap::Args;
 
-use crate::cli::parse_color;
 use crate::effects::common::{
     parse_gradient_direction, parse_gradient_steps, parse_non_negative_float, parse_positive_float,
     parse_positive_float_range, parse_positive_int,
@@ -18,7 +17,7 @@ use crate::engine::events::EffectCallback;
 use crate::engine::terminal::{CharacterFilter, CharacterSort};
 use crate::utils::easing::Easing;
 use crate::utils::geometry::{self, Coord};
-use crate::utils::graphics::{Color, ColorPair, Gradient, GradientDirection};
+use crate::utils::graphics::{parse_color, Color, ColorPair, Gradient, GradientDirection};
 use crate::utils::pycompat::floor_div;
 
 #[derive(Args, Debug, Clone)]
@@ -56,6 +55,21 @@ pub struct SpotlightsConfig {
     /// Direction of the final gradient.
     #[arg(long = "final-gradient-direction", default_value = "vertical", value_parser = parse_gradient_direction)]
     pub final_gradient_direction: GradientDirection,
+}
+
+impl Default for SpotlightsConfig {
+    fn default() -> Self {
+        Self {
+            beam_width_ratio: 2.0,
+            beam_falloff: 0.3,
+            search_duration: 550,
+            search_speed_range: parse_positive_float_range("0.35-0.75").expect("default search_speed_range"),
+            spotlight_count: 3,
+            final_gradient_stops: ["ab48ff", "e7b2b2", "fffebd"].into_iter().map(|v| parse_color(v).expect("default final_gradient_stops")).collect(),
+            final_gradient_steps: ["12"].into_iter().map(|v| parse_gradient_steps(v).expect("default final_gradient_steps")).collect(),
+            final_gradient_direction: parse_gradient_direction("vertical").expect("default final_gradient_direction"),
+        }
+    }
 }
 
 pub struct Spotlights {

--- a/src/effects/spray.rs
+++ b/src/effects/spray.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 
 use clap::Args;
 
-use crate::cli::parse_color;
 use crate::effects::common::{
     parse_easing, parse_gradient_direction, parse_gradient_steps, parse_positive_float_range, parse_positive_ratio,
 };
@@ -17,7 +16,7 @@ use crate::engine::events::{CallerKey, EffectCallback, Event, EventAction};
 use crate::engine::terminal::{CharacterFilter, CharacterSort};
 use crate::utils::easing::Easing;
 use crate::utils::geometry::Coord;
-use crate::utils::graphics::{Color, ColorPair, Gradient, GradientDirection};
+use crate::utils::graphics::{parse_color, Color, ColorPair, Gradient, GradientDirection};
 use crate::utils::pycompat::floor_div;
 
 /// SprayIterator.SprayPosition.
@@ -84,6 +83,20 @@ pub struct SprayConfig {
     /// Direction of the final gradient.
     #[arg(long = "final-gradient-direction", default_value = "vertical", value_parser = parse_gradient_direction)]
     pub final_gradient_direction: GradientDirection,
+}
+
+impl Default for SprayConfig {
+    fn default() -> Self {
+        Self {
+            spray_position: parse_spray_position("e").expect("default spray_position"),
+            spray_volume: 0.005,
+            movement_speed_range: parse_positive_float_range("0.6-1.4").expect("default movement_speed_range"),
+            movement_easing: parse_easing("out_expo").expect("default movement_easing"),
+            final_gradient_stops: ["8A008A", "00D1FF", "FFFFFF"].into_iter().map(|v| parse_color(v).expect("default final_gradient_stops")).collect(),
+            final_gradient_steps: ["12"].into_iter().map(|v| parse_gradient_steps(v).expect("default final_gradient_steps")).collect(),
+            final_gradient_direction: parse_gradient_direction("vertical").expect("default final_gradient_direction"),
+        }
+    }
 }
 
 pub struct Spray {

--- a/src/effects/swarm.rs
+++ b/src/effects/swarm.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 
 use clap::Args;
 
-use crate::cli::parse_color;
 use crate::effects::common::{
     parse_gradient_direction, parse_gradient_steps, parse_non_negative_ratio, parse_positive_int_range,
 };
@@ -17,7 +16,7 @@ use crate::engine::events::{CallerKey, EffectCallback, Event, EventAction};
 use crate::engine::terminal::{CharacterFilter, CharacterSort};
 use crate::utils::easing::Easing;
 use crate::utils::geometry::{self, Coord};
-use crate::utils::graphics::{Color, ColorPair, Gradient, GradientDirection};
+use crate::utils::graphics::{parse_color, Color, ColorPair, Gradient, GradientDirection};
 use crate::utils::pycompat::{floor_div, round_half_even};
 
 #[derive(Args, Debug, Clone)]
@@ -56,6 +55,21 @@ pub struct SwarmConfig {
     /// Direction of the final gradient.
     #[arg(long = "final-gradient-direction", default_value = "horizontal", value_parser = parse_gradient_direction)]
     pub final_gradient_direction: GradientDirection,
+}
+
+impl Default for SwarmConfig {
+    fn default() -> Self {
+        Self {
+            base_color: ["31a0d4"].into_iter().map(|v| parse_color(v).expect("default base_color")).collect(),
+            flash_color: parse_color("f2ea79").expect("default flash_color"),
+            swarm_size: 0.1,
+            swarm_coordination: 0.80,
+            swarm_area_count_range: parse_positive_int_range("2-4").expect("default swarm_area_count_range"),
+            final_gradient_stops: ["31b900", "f0ff65"].into_iter().map(|v| parse_color(v).expect("default final_gradient_stops")).collect(),
+            final_gradient_steps: ["12"].into_iter().map(|v| parse_gradient_steps(v).expect("default final_gradient_steps")).collect(),
+            final_gradient_direction: parse_gradient_direction("horizontal").expect("default final_gradient_direction"),
+        }
+    }
 }
 
 pub struct Swarm {

--- a/src/effects/sweep.rs
+++ b/src/effects/sweep.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 
 use clap::Args;
 
-use crate::cli::parse_color;
 use crate::effects::common::{
     parse_character_group, parse_gradient_direction, parse_gradient_steps, parse_symbol,
 };
@@ -16,7 +15,7 @@ use crate::engine::error::EngineError;
 use crate::engine::events::EffectCallback;
 use crate::engine::terminal::{CharacterFilter, CharacterGroup, CharacterSort};
 use crate::utils::easing::{Easing, SequenceEaser};
-use crate::utils::graphics::{Color, ColorPair, Gradient, GradientDirection};
+use crate::utils::graphics::{parse_color, Color, ColorPair, Gradient, GradientDirection};
 
 #[derive(Args, Debug, Clone)]
 pub struct SweepConfig {
@@ -48,6 +47,19 @@ pub struct SweepConfig {
     /// Direction of the final gradient.
     #[arg(long = "final-gradient-direction", default_value = "vertical", value_parser = parse_gradient_direction)]
     pub final_gradient_direction: GradientDirection,
+}
+
+impl Default for SweepConfig {
+    fn default() -> Self {
+        Self {
+            sweep_symbols: ["█", "▓", "▒", "░"].into_iter().map(|v| parse_symbol(v).expect("default sweep_symbols")).collect(),
+            first_sweep_direction: parse_character_group("column_right_to_left").expect("default first_sweep_direction"),
+            second_sweep_direction: parse_character_group("column_left_to_right").expect("default second_sweep_direction"),
+            final_gradient_stops: ["8A008A", "00D1FF", "ffffff"].into_iter().map(|v| parse_color(v).expect("default final_gradient_stops")).collect(),
+            final_gradient_steps: ["8"].into_iter().map(|v| parse_gradient_steps(v).expect("default final_gradient_steps")).collect(),
+            final_gradient_direction: parse_gradient_direction("vertical").expect("default final_gradient_direction"),
+        }
+    }
 }
 
 pub struct Sweep {

--- a/src/effects/synthgrid.rs
+++ b/src/effects/synthgrid.rs
@@ -12,7 +12,6 @@ use std::collections::HashMap;
 
 use clap::Args;
 
-use crate::cli::parse_color;
 use crate::effects::common::{
     parse_gradient_direction, parse_gradient_steps, parse_positive_ratio, parse_symbol,
 };
@@ -24,7 +23,7 @@ use crate::engine::error::EngineError;
 use crate::engine::events::{CallbackValue, CallerKey, EffectCallback, Event, EventAction};
 use crate::engine::terminal::{CharacterFilter, CharacterSort};
 use crate::utils::geometry::Coord;
-use crate::utils::graphics::{Color, ColorPair, CoordColorMap, Gradient, GradientDirection};
+use crate::utils::graphics::{parse_color, Color, ColorPair, CoordColorMap, Gradient, GradientDirection};
 use crate::utils::pycompat::floor_div;
 
 /// Callback id: update_group_tracker(group_number) — decrements the tracker.
@@ -76,6 +75,23 @@ pub struct SynthGridConfig {
     /// Maximum percentage of blocks to have active at any given time. For example, if set to 0.1, 10 percent of the blocks will be active at any given time.
     #[arg(long = "max-active-blocks", default_value_t = 0.1, value_parser = parse_positive_ratio)]
     pub max_active_blocks: f64,
+}
+
+impl Default for SynthGridConfig {
+    fn default() -> Self {
+        Self {
+            grid_gradient_stops: ["CC00CC", "ffffff"].into_iter().map(|v| parse_color(v).expect("default grid_gradient_stops")).collect(),
+            grid_gradient_steps: ["12"].into_iter().map(|v| parse_gradient_steps(v).expect("default grid_gradient_steps")).collect(),
+            grid_gradient_direction: parse_gradient_direction("diagonal").expect("default grid_gradient_direction"),
+            text_gradient_stops: ["8A008A", "00D1FF", "FFFFFF"].into_iter().map(|v| parse_color(v).expect("default text_gradient_stops")).collect(),
+            text_gradient_steps: ["12"].into_iter().map(|v| parse_gradient_steps(v).expect("default text_gradient_steps")).collect(),
+            text_gradient_direction: parse_gradient_direction("vertical").expect("default text_gradient_direction"),
+            grid_row_symbol: parse_symbol("─").expect("default grid_row_symbol"),
+            grid_column_symbol: parse_symbol("│").expect("default grid_column_symbol"),
+            text_generation_symbols: ["░", "▒", "▓"].into_iter().map(|v| parse_symbol(v).expect("default text_generation_symbols")).collect(),
+            max_active_blocks: 0.1,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/effects/thunderstorm.rs
+++ b/src/effects/thunderstorm.rs
@@ -11,7 +11,6 @@
 
 use clap::Args;
 
-use crate::cli::parse_color;
 use crate::effects::common::{parse_gradient_direction, parse_gradient_steps, parse_positive_int, parse_symbol};
 use crate::engine::animation::{Animation, ExistingColorHandling, Scene, VisualParams};
 use crate::engine::character::CharId;
@@ -23,7 +22,7 @@ use crate::engine::particles::{ParticlePool, ParticleReset};
 use crate::engine::terminal::{CharacterFilter, CharacterSort};
 use crate::utils::easing::Easing;
 use crate::utils::geometry::Coord;
-use crate::utils::graphics::{Color, ColorPair, Gradient, GradientDirection};
+use crate::utils::graphics::{parse_color, Color, ColorPair, Gradient, GradientDirection};
 use crate::utils::pycompat::floor_div;
 
 /// fade_complete (effect_thunderstorm.py:388): phase -> storm, restart clock.
@@ -94,6 +93,25 @@ pub struct ThunderstormConfig {
     /// Direction of the final gradient.
     #[arg(long = "final-gradient-direction", default_value = "vertical", value_parser = parse_gradient_direction)]
     pub final_gradient_direction: GradientDirection,
+}
+
+impl Default for ThunderstormConfig {
+    fn default() -> Self {
+        Self {
+            lightning_color: parse_color("68A3E8").expect("default lightning_color"),
+            glowing_text_color: parse_color("EF5411").expect("default glowing_text_color"),
+            text_glow_time: 6,
+            raindrop_symbols: ["\\", ".", ","].into_iter().map(|v| parse_symbol(v).expect("default raindrop_symbols")).collect(),
+            spark_symbols: ["*", ".", "'"].into_iter().map(|v| parse_symbol(v).expect("default spark_symbols")).collect(),
+            spark_glow_color: parse_color("ff4d00").expect("default spark_glow_color"),
+            spark_glow_time: 18,
+            storm_time: 12,
+            final_gradient_stops: ["8A008A", "00D1FF", "FFFFFF"].into_iter().map(|v| parse_color(v).expect("default final_gradient_stops")).collect(),
+            final_gradient_steps: ["12"].into_iter().map(|v| parse_gradient_steps(v).expect("default final_gradient_steps")).collect(),
+            final_gradient_frames: 3,
+            final_gradient_direction: parse_gradient_direction("vertical").expect("default final_gradient_direction"),
+        }
+    }
 }
 
 /// self.phase string states.

--- a/src/effects/unstable.rs
+++ b/src/effects/unstable.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 
 use clap::Args;
 
-use crate::cli::parse_color;
 use crate::effects::common::{parse_easing, parse_gradient_direction, parse_gradient_steps, parse_positive_float};
 use crate::engine::animation::{ExistingColorHandling, VisualParams};
 use crate::engine::character::CharId;
@@ -15,7 +14,7 @@ use crate::engine::events::EffectCallback;
 use crate::engine::terminal::{CharacterFilter, CharacterSort};
 use crate::utils::easing::Easing;
 use crate::utils::geometry::Coord;
-use crate::utils::graphics::{Color, ColorPair, Gradient, GradientDirection};
+use crate::utils::graphics::{parse_color, Color, ColorPair, Gradient, GradientDirection};
 
 #[derive(Args, Debug, Clone)]
 pub struct UnstableConfig {
@@ -52,6 +51,21 @@ pub struct UnstableConfig {
     /// Direction of the final gradient.
     #[arg(long = "final-gradient-direction", default_value = "vertical", value_parser = parse_gradient_direction)]
     pub final_gradient_direction: GradientDirection,
+}
+
+impl Default for UnstableConfig {
+    fn default() -> Self {
+        Self {
+            unstable_color: parse_color("ff9200").expect("default unstable_color"),
+            explosion_ease: parse_easing("out_expo").expect("default explosion_ease"),
+            explosion_speed: 1.0,
+            reassembly_ease: parse_easing("out_expo").expect("default reassembly_ease"),
+            reassembly_speed: 1.0,
+            final_gradient_stops: ["8A008A", "00D1FF", "FFFFFF"].into_iter().map(|v| parse_color(v).expect("default final_gradient_stops")).collect(),
+            final_gradient_steps: ["12"].into_iter().map(|v| parse_gradient_steps(v).expect("default final_gradient_steps")).collect(),
+            final_gradient_direction: parse_gradient_direction("vertical").expect("default final_gradient_direction"),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/effects/vhstape.rs
+++ b/src/effects/vhstape.rs
@@ -11,7 +11,6 @@ use std::collections::HashMap;
 
 use clap::Args;
 
-use crate::cli::parse_color;
 use crate::effects::common::{
     parse_gradient_direction, parse_gradient_steps, parse_non_negative_ratio, parse_positive_int,
 };
@@ -23,7 +22,7 @@ use crate::engine::error::EngineError;
 use crate::engine::events::{CallerKey, EffectCallback, Event, EventAction};
 use crate::engine::terminal::{CharacterFilter, CharacterGroup, CharacterSort};
 use crate::utils::geometry::Coord;
-use crate::utils::graphics::{Color, ColorPair, Gradient, GradientDirection};
+use crate::utils::graphics::{parse_color, Color, ColorPair, Gradient, GradientDirection};
 use crate::utils::pycompat::round_half_even;
 
 #[derive(Args, Debug, Clone)]
@@ -68,6 +67,22 @@ pub struct VhsTapeConfig {
     /// Direction of the final gradient.
     #[arg(long = "final-gradient-direction", default_value = "vertical", value_parser = parse_gradient_direction)]
     pub final_gradient_direction: GradientDirection,
+}
+
+impl Default for VhsTapeConfig {
+    fn default() -> Self {
+        Self {
+            glitch_line_colors: ["ffffff", "ff0000", "00ff00", "0000ff", "ffffff"].into_iter().map(|v| parse_color(v).expect("default glitch_line_colors")).collect(),
+            glitch_wave_colors: ["ffffff", "ff0000", "00ff00", "0000ff", "ffffff"].into_iter().map(|v| parse_color(v).expect("default glitch_wave_colors")).collect(),
+            noise_colors: ["1e1e1f", "3c3b3d", "6d6c70", "a2a1a6", "cbc9cf", "ffffff"].into_iter().map(|v| parse_color(v).expect("default noise_colors")).collect(),
+            glitch_line_chance: 0.05,
+            noise_chance: 0.004,
+            total_glitch_time: 600,
+            final_gradient_stops: ["ab48ff", "e7b2b2", "fffebd"].into_iter().map(|v| parse_color(v).expect("default final_gradient_stops")).collect(),
+            final_gradient_steps: ["12"].into_iter().map(|v| parse_gradient_steps(v).expect("default final_gradient_steps")).collect(),
+            final_gradient_direction: parse_gradient_direction("vertical").expect("default final_gradient_direction"),
+        }
+    }
 }
 
 /// VHSTapeIterator.Line state (methods live on VhsTape for hooks access).

--- a/src/effects/waves.rs
+++ b/src/effects/waves.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 
 use clap::Args;
 
-use crate::cli::parse_color;
 use crate::effects::common::{
     parse_easing, parse_gradient_direction, parse_gradient_steps, parse_positive_int, parse_symbol,
 };
@@ -16,7 +15,7 @@ use crate::engine::error::EngineError;
 use crate::engine::events::{CallerKey, EffectCallback, Event, EventAction};
 use crate::engine::terminal::{CharacterFilter, CharacterGroup, CharacterSort};
 use crate::utils::easing::Easing;
-use crate::utils::graphics::{Color, ColorPair, Gradient, GradientDirection};
+use crate::utils::graphics::{parse_color, Color, ColorPair, Gradient, GradientDirection};
 
 /// waves --wave-direction choices (a subset of CharacterGroup, upstream grouping_map).
 fn parse_wave_direction(s: &str) -> Result<CharacterGroup, String> {
@@ -77,6 +76,23 @@ pub struct WavesConfig {
     /// Direction of the final gradient.
     #[arg(long = "final-gradient-direction", default_value = "diagonal", value_parser = parse_gradient_direction)]
     pub final_gradient_direction: GradientDirection,
+}
+
+impl Default for WavesConfig {
+    fn default() -> Self {
+        Self {
+            wave_symbols: ["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█", "▇", "▆", "▅", "▄", "▃", "▂", "▁"].into_iter().map(|v| parse_symbol(v).expect("default wave_symbols")).collect(),
+            wave_gradient_stops: ["f0ff65", "ffb102", "31a0d4", "ffb102", "f0ff65"].into_iter().map(|v| parse_color(v).expect("default wave_gradient_stops")).collect(),
+            wave_gradient_steps: ["6"].into_iter().map(|v| parse_gradient_steps(v).expect("default wave_gradient_steps")).collect(),
+            wave_count: 7,
+            wave_length: 2,
+            wave_direction: parse_wave_direction("column_left_to_right").expect("default wave_direction"),
+            wave_easing: parse_easing("in_out_sine").expect("default wave_easing"),
+            final_gradient_stops: ["ffb102", "31a0d4", "f0ff65"].into_iter().map(|v| parse_color(v).expect("default final_gradient_stops")).collect(),
+            final_gradient_steps: ["12"].into_iter().map(|v| parse_gradient_steps(v).expect("default final_gradient_steps")).collect(),
+            final_gradient_direction: parse_gradient_direction("diagonal").expect("default final_gradient_direction"),
+        }
+    }
 }
 
 pub struct Waves {

--- a/src/effects/wipe.rs
+++ b/src/effects/wipe.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 
 use clap::Args;
 
-use crate::cli::parse_color;
 use crate::effects::common::{
     parse_character_group, parse_easing, parse_gradient_direction, parse_gradient_steps, parse_non_negative_int,
 };
@@ -16,7 +15,7 @@ use crate::engine::error::EngineError;
 use crate::engine::events::EffectCallback;
 use crate::engine::terminal::{CharacterFilter, CharacterGroup, CharacterSort};
 use crate::utils::easing::{Easing, SequenceEaser};
-use crate::utils::graphics::{Color, ColorPair, Gradient, GradientDirection};
+use crate::utils::graphics::{parse_color, Color, ColorPair, Gradient, GradientDirection};
 
 #[derive(Args, Debug, Clone)]
 pub struct WipeConfig {
@@ -50,6 +49,20 @@ pub struct WipeConfig {
     /// Direction of the final gradient.
     #[arg(long = "final-gradient-direction", default_value = "vertical", value_parser = parse_gradient_direction)]
     pub final_gradient_direction: GradientDirection,
+}
+
+impl Default for WipeConfig {
+    fn default() -> Self {
+        Self {
+            wipe_direction: parse_character_group("diagonal_top_left_to_bottom_right").expect("default wipe_direction"),
+            wipe_delay: 0,
+            wipe_ease: parse_easing("in_out_circ").expect("default wipe_ease"),
+            final_gradient_stops: ["833ab4", "fd1d1d", "fcb045"].into_iter().map(|v| parse_color(v).expect("default final_gradient_stops")).collect(),
+            final_gradient_steps: ["12"].into_iter().map(|v| parse_gradient_steps(v).expect("default final_gradient_steps")).collect(),
+            final_gradient_frames: 3,
+            final_gradient_direction: parse_gradient_direction("vertical").expect("default final_gradient_direction"),
+        }
+    }
 }
 
 pub struct Wipe {

--- a/src/engine/animation.rs
+++ b/src/engine/animation.rs
@@ -5,7 +5,9 @@
 use std::collections::VecDeque;
 use std::rc::Rc;
 
-use crate::utils::ansi::{self, ColorCode};
+use crate::utils::ansi::ColorCode;
+#[cfg(not(target_arch = "wasm32"))]
+use crate::utils::ansi;
 use crate::utils::easing::Easing;
 use crate::utils::graphics::{Color, ColorPair, Gradient};
 use crate::utils::hexterm;
@@ -25,6 +27,7 @@ pub enum SyncMetric {
     Step,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 thread_local! {
     /// Reused assembly buffer for CharacterVisual::new's SGR string.
     static FORMAT_SCRATCH: std::cell::RefCell<String> = const { std::cell::RefCell::new(String::new()) };
@@ -32,6 +35,7 @@ thread_local! {
 
 /// Inline capacity for a formatted symbol. A 24-bit foreground and background
 /// pair plus a reset is 42 bytes, so all but pathological styling fits.
+#[cfg(not(target_arch = "wasm32"))]
 const INLINE_SYMBOL_CAPACITY: usize = 63;
 
 /// The precomputed ANSI string for one cell, stored inline when it fits.
@@ -40,12 +44,16 @@ const INLINE_SYMBOL_CAPACITY: usize = 63;
 /// over a run — and a `str` copy of a couple of dozen bytes is dominated by the
 /// memcpy call itself. An inline buffer of fixed size lets the writer copy the
 /// whole block unconditionally and then advance by the real length.
+///
+/// Wasm packed frames read symbol/color fields directly, so this stays native.
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(Debug, Clone)]
 pub enum FormattedSymbol {
     Inline { bytes: [u8; INLINE_SYMBOL_CAPACITY], len: u8 },
     Heap(Box<str>),
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl FormattedSymbol {
     fn new(text: &str) -> Self {
         if text.len() <= INLINE_SYMBOL_CAPACITY {
@@ -93,6 +101,7 @@ impl FormattedSymbol {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl PartialEq for FormattedSymbol {
     fn eq(&self, other: &Self) -> bool {
         self.as_str() == other.as_str()
@@ -114,6 +123,7 @@ pub struct CharacterVisual {
     pub colors: Option<ColorPair>,
     pub fg_color_code: Option<ColorCode>,
     pub bg_color_code: Option<ColorCode>,
+    #[cfg(not(target_arch = "wasm32"))]
     pub formatted_symbol: FormattedSymbol,
 }
 
@@ -134,6 +144,7 @@ pub struct VisualParams {
 
 impl CharacterVisual {
     pub fn new(symbol: &str, p: VisualParams) -> Self {
+        #[cfg_attr(target_arch = "wasm32", allow(unused_mut))]
         let mut vis = CharacterVisual {
             symbol: symbol.to_string(),
             bold: p.bold,
@@ -147,10 +158,13 @@ impl CharacterVisual {
             colors: p.colors,
             fg_color_code: p.fg_color_code,
             bg_color_code: p.bg_color_code,
+            #[cfg(not(target_arch = "wasm32"))]
             formatted_symbol: FormattedSymbol::Inline { bytes: [0; INLINE_SYMBOL_CAPACITY], len: 0 },
         };
         // Effects rebuild visuals every frame, so the SGR string is assembled in
         // a reused scratch buffer rather than a fresh allocation per visual.
+        // Wasm packed frames never read it.
+        #[cfg(not(target_arch = "wasm32"))]
         FORMAT_SCRATCH.with(|scratch| {
             let mut scratch = scratch.borrow_mut();
             scratch.clear();
@@ -166,6 +180,7 @@ impl CharacterVisual {
 
     /// SGR emission in upstream's fixed order; `dim` intentionally omitted;
     /// bare symbol when nothing applies.
+    #[cfg(not(target_arch = "wasm32"))]
     fn format_symbol_into(&self, fmt: &mut String) {
         if self.bold {
             fmt.push_str(ansi::BOLD);

--- a/src/engine/animation.rs
+++ b/src/engine/animation.rs
@@ -654,12 +654,10 @@ impl Animation {
             )
         };
 
-        let adjusted = format!(
-            "{:02x}{:02x}{:02x}",
-            round_half_even(red * 255.0),
-            round_half_even(green * 255.0),
-            round_half_even(blue * 255.0)
-        );
-        Color::from_hex(&adjusted).unwrap()
+        Color::from_rgb(
+            round_half_even(red * 255.0) as u8,
+            round_half_even(green * 255.0) as u8,
+            round_half_even(blue * 255.0) as u8,
+        )
     }
 }

--- a/src/engine/animation.rs
+++ b/src/engine/animation.rs
@@ -10,6 +10,7 @@ use crate::utils::ansi::ColorCode;
 use crate::utils::ansi;
 use crate::utils::easing::Easing;
 use crate::utils::graphics::{Color, ColorPair, Gradient};
+#[cfg(not(target_arch = "wasm32"))]
 use crate::utils::hexterm;
 use crate::utils::ordered_map::OrderedMap;
 
@@ -234,6 +235,7 @@ pub struct Scene {
     pub sync: Option<SyncMetric>,
     pub ease: Option<Easing>,
     pub no_color: bool,
+    #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
     pub use_xterm_colors: bool,
     /// Stable frame storage; never reordered.
     pub all_frames: Vec<Frame>,
@@ -283,6 +285,8 @@ impl Scene {
         if self.no_color {
             return None;
         }
+        // Wasm Session never sets xterm_colors; packed frames want 24-bit RGB.
+        #[cfg(not(target_arch = "wasm32"))]
         if self.use_xterm_colors {
             if let Some(code) = color.xterm_color {
                 return Some(ColorCode::Xterm(code));
@@ -451,6 +455,7 @@ impl Scene {
 pub struct Animation {
     pub scenes: OrderedMap<Scene>,
     pub active_scene: Option<Rc<str>>,
+    #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
     pub use_xterm_colors: bool,
     pub no_color: bool,
     pub existing_color_handling: ExistingColorHandling,
@@ -484,6 +489,7 @@ impl Animation {
         if self.no_color {
             return None;
         }
+        #[cfg(not(target_arch = "wasm32"))]
         if self.use_xterm_colors {
             if let Some(code) = color.xterm_color {
                 return Some(ColorCode::Xterm(code));

--- a/src/engine/animation.rs
+++ b/src/engine/animation.rs
@@ -280,6 +280,9 @@ impl Scene {
 
     /// Scene._get_color_code. Upstream memoizes into a process-global ClassVar
     /// dict; the memo is value-transparent so we just recompute.
+    ///
+    /// Wasm packed frames read `Color` RGB, so this SGR code stays native.
+    #[cfg(not(target_arch = "wasm32"))]
     fn get_color_code(&self, color: Option<&Color>) -> Option<ColorCode> {
         let color = color?;
         if self.no_color {
@@ -304,6 +307,7 @@ impl Scene {
         if self.preexisting_bold {
             params.bold = true;
         }
+        #[cfg(not(target_arch = "wasm32"))]
         if let Some(colors) = &params.colors {
             params.fg_color_code = self.get_color_code(colors.fg_color.as_ref());
             params.bg_color_code = self.get_color_code(colors.bg_color.as_ref());
@@ -484,6 +488,7 @@ impl Animation {
 
     /// Animation._get_color_code (identical logic to Scene's; the upstream
     /// per-instance memo is value-transparent and omitted).
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn get_color_code(&mut self, color: Option<&Color>) -> Option<ColorCode> {
         let color = color?;
         if self.no_color {
@@ -563,15 +568,15 @@ impl Animation {
             colors = ColorPair::new(self.input_fg_color.clone(), self.input_bg_color.clone());
             bold = self.input_bold;
         }
-        let fg_code = self.get_color_code(colors.fg_color.as_ref());
-        let bg_code = self.get_color_code(colors.bg_color.as_ref());
         self.current_character_visual = Rc::new(CharacterVisual::new(
             symbol,
             VisualParams {
                 bold,
                 colors: Some(colors),
-                fg_color_code: fg_code,
-                bg_color_code: bg_code,
+                #[cfg(not(target_arch = "wasm32"))]
+                fg_color_code: self.get_color_code(colors.fg_color.as_ref()),
+                #[cfg(not(target_arch = "wasm32"))]
+                bg_color_code: self.get_color_code(colors.bg_color.as_ref()),
                 ..Default::default()
             },
         ));

--- a/src/engine/ctx.rs
+++ b/src/engine/ctx.rs
@@ -694,11 +694,22 @@ impl EngineCtx {
 
     /// BaseEffectIterator.frame: enforce framerate (real clock only), then the
     /// formatted output string; advances the virtual clock by one frame.
+    ///
+    /// Wasm skips ANSI emission. The browser reads packed cells from
+    /// `pack_display_frame`, which paints once. Building the string here would
+    /// allocate and paint a second time for output JS never reads.
     pub fn frame(&mut self) -> String {
         if matches!(self.clock, Clock::Real { .. }) && self.terminal.config.frame_rate != 0 {
             self.terminal.enforce_framerate();
         }
         self.clock.advance_frame();
-        self.terminal.get_formatted_output_string()
+        #[cfg(target_arch = "wasm32")]
+        {
+            String::new()
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            self.terminal.get_formatted_output_string()
+        }
     }
 }

--- a/src/engine/ctx.rs
+++ b/src/engine/ctx.rs
@@ -699,6 +699,7 @@ impl EngineCtx {
     /// `pack_display_frame`, which paints once. Building the string here would
     /// allocate and paint a second time for output JS never reads.
     pub fn frame(&mut self) -> String {
+        #[cfg(not(target_arch = "wasm32"))]
         if matches!(self.clock, Clock::Real { .. }) && self.terminal.config.frame_rate != 0 {
             self.terminal.enforce_framerate();
         }

--- a/src/engine/effect.rs
+++ b/src/engine/effect.rs
@@ -1,5 +1,6 @@
 //! Effect trait and run loop (base_effect.py equivalents).
 
+#[cfg(not(target_arch = "wasm32"))]
 use std::io::Write;
 
 use crate::engine::ctx::{EffectHooks, EngineCtx};
@@ -13,6 +14,7 @@ pub trait Effect: EffectHooks {
     fn next_frame(&mut self, ctx: &mut EngineCtx) -> Option<String>;
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RunOutcome {
     Complete,
@@ -31,6 +33,7 @@ pub enum RunOutcome {
 /// the top of the area so the caller can rebuild in place, and a terminal that
 /// goes away ends the run. A redirected stream gets neither: SIGWINCH there is
 /// not about our output, and a write that fails to a file is a real failure.
+#[cfg(not(target_arch = "wasm32"))]
 pub fn run_effect(
     effect: &mut dyn Effect,
     ctx: &mut EngineCtx,
@@ -85,11 +88,13 @@ pub fn run_effect(
 /// EIO is the pty slave outliving its master; EPIPE only surfaces here when
 /// SIGPIPE was ignored by whoever started us, since we restore its default.
 /// Both mean the same thing, and neither is a failure of this run.
+#[cfg(not(target_arch = "wasm32"))]
 fn output_closed(e: &std::io::Error) -> bool {
     const EIO: i32 = 5;
     e.kind() == std::io::ErrorKind::BrokenPipe || e.raw_os_error() == Some(EIO)
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn requested_stop(ctx: &mut EngineCtx, stop_on_resize: bool) -> Option<RunOutcome> {
     if crate::interrupted() {
         Some(RunOutcome::Interrupted)
@@ -103,6 +108,7 @@ fn requested_stop(ctx: &mut EngineCtx, stop_on_resize: bool) -> Option<RunOutcom
 }
 
 /// Parity mode: write length-prefixed frames to stdout, no tty escapes.
+#[cfg(not(target_arch = "wasm32"))]
 pub fn dump_effect(
     effect: &mut dyn Effect,
     ctx: &mut EngineCtx,
@@ -128,6 +134,7 @@ pub fn dump_effect(
     Ok(count)
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn io_err(e: std::io::Error) -> EngineError {
     EngineError::Other(format!("io error: {e}"))
 }

--- a/src/engine/error.rs
+++ b/src/engine/error.rs
@@ -11,10 +11,12 @@ pub enum EngineError {
 impl std::fmt::Display for EngineError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            EngineError::UnsupportedAnsiSequence(seq) => {
-                write!(f, "Unsupported ANSI sequence in input data: {seq:?}")
+            // Debug of the sequence pulled unicode/printable into every wasm.
+            // The CLI still prints `{seq:?}` itself; Session only needs the tag.
+            EngineError::UnsupportedAnsiSequence(_) => {
+                f.write_str("Unsupported ANSI sequence in input data")
             }
-            EngineError::Other(msg) => write!(f, "{msg}"),
+            EngineError::Other(msg) => f.write_str(msg),
         }
     }
 }

--- a/src/engine/events.rs
+++ b/src/engine/events.rs
@@ -172,11 +172,10 @@ impl EventHandler {
         });
         if let Some(entry) = existing {
             if entry.actions.contains(&action) {
-                return Err(format!(
-                    "duplicate event registration: {:?} {:?}",
-                    (entry.event, &entry.caller),
-                    action
-                ));
+                // Keep this message a static string. Debug-printing `action`
+                // pulls `CallbackValue::Float`'s formatter (and flt2dec) into
+                // every wasm artifact, including effects that never store a float.
+                return Err("duplicate event registration".to_string());
             }
             entry.actions.push(action);
         } else {

--- a/src/engine/input.rs
+++ b/src/engine/input.rs
@@ -30,7 +30,11 @@ impl ColorFrequency {
 
 #[derive(Clone, Default)]
 struct ActiveState {
+    /// Captured SGR text for native replay. Wasm packed frames read Color RGB,
+    /// so these strings stay native-only.
+    #[cfg(not(target_arch = "wasm32"))]
     fg_sequence: String, // "" = none, like upstream's active_sequences
+    #[cfg(not(target_arch = "wasm32"))]
     bg_sequence: String,
     fg_color: Option<Color>,
     bg_color: Option<Color>,
@@ -147,19 +151,21 @@ impl<'a> Preprocessor<'a> {
         let mut ch = EffectCharacter::new(*self.next_character_id, symbol, 0, 0);
         *self.next_character_id += 1;
         // fg first, then bg — upstream dict iteration order over active_sequences
-        if !state.fg_sequence.is_empty() {
-            if let Some(color) = &state.fg_color {
+        if let Some(color) = &state.fg_color {
+            #[cfg(not(target_arch = "wasm32"))]
+            {
                 ch.input_ansi_fg_sequence = Some(state.fg_sequence.clone());
-                self.input_colors_frequency.increment(color);
-                ch.animation.input_fg_color = Some(color.clone());
             }
+            self.input_colors_frequency.increment(color);
+            ch.animation.input_fg_color = Some(color.clone());
         }
-        if !state.bg_sequence.is_empty() {
-            if let Some(color) = &state.bg_color {
+        if let Some(color) = &state.bg_color {
+            #[cfg(not(target_arch = "wasm32"))]
+            {
                 ch.input_ansi_bg_sequence = Some(state.bg_sequence.clone());
-                self.input_colors_frequency.increment(color);
-                ch.animation.input_bg_color = Some(color.clone());
             }
+            self.input_colors_frequency.increment(color);
+            ch.animation.input_bg_color = Some(color.clone());
         }
         ch.animation.input_bold = state.bold;
         ch.animation.no_color = self.config.no_color;
@@ -190,8 +196,11 @@ impl<'a> Preprocessor<'a> {
             let parameter = parameters[idx];
             match parameter {
                 0 => {
-                    state.fg_sequence.clear();
-                    state.bg_sequence.clear();
+                    #[cfg(not(target_arch = "wasm32"))]
+                    {
+                        state.fg_sequence.clear();
+                        state.bg_sequence.clear();
+                    }
                     state.fg_color = None;
                     state.bg_color = None;
                     state.bold = false;
@@ -210,34 +219,48 @@ impl<'a> Preprocessor<'a> {
                     }
                 }
                 39 => {
+                    #[cfg(not(target_arch = "wasm32"))]
                     state.fg_sequence.clear();
                     state.fg_color = None;
                     state.standard_fg_parameter = None;
                 }
                 49 => {
+                    #[cfg(not(target_arch = "wasm32"))]
                     state.bg_sequence.clear();
                     state.bg_color = None;
                 }
                 30..=37 => {
                     let color = xterm_color(parameter - 30 + if state.bold { 8 } else { 0 })?;
-                    state.fg_sequence = format!("\x1b[{parameter}m");
+                    #[cfg(not(target_arch = "wasm32"))]
+                    {
+                        state.fg_sequence = format!("\x1b[{parameter}m");
+                    }
                     state.fg_color = Some(color);
                     state.standard_fg_parameter = Some(parameter);
                 }
                 90..=97 => {
                     let color = xterm_color(parameter - 90 + 8)?;
-                    state.fg_sequence = format!("\x1b[{parameter}m");
+                    #[cfg(not(target_arch = "wasm32"))]
+                    {
+                        state.fg_sequence = format!("\x1b[{parameter}m");
+                    }
                     state.fg_color = Some(color);
                     state.standard_fg_parameter = None;
                 }
                 40..=47 => {
                     let color = xterm_color(parameter - 40)?;
-                    state.bg_sequence = format!("\x1b[{parameter}m");
+                    #[cfg(not(target_arch = "wasm32"))]
+                    {
+                        state.bg_sequence = format!("\x1b[{parameter}m");
+                    }
                     state.bg_color = Some(color);
                 }
                 100..=107 => {
                     let color = xterm_color(parameter - 100 + 8)?;
-                    state.bg_sequence = format!("\x1b[{parameter}m");
+                    #[cfg(not(target_arch = "wasm32"))]
+                    {
+                        state.bg_sequence = format!("\x1b[{parameter}m");
+                    }
                     state.bg_color = Some(color);
                 }
                 38 | 48 => {
@@ -245,9 +268,8 @@ impl<'a> Preprocessor<'a> {
                         return Err(EngineError::UnsupportedAnsiSequence(sequence.to_string()));
                     }
                     let is_fg = parameter == 38;
-                    let selector = parameter;
                     let color_mode = parameters[idx + 1];
-                    let (normalized_sequence, color) = match color_mode {
+                    let color = match color_mode {
                         5 => {
                             if idx + 2 >= parameters.len() {
                                 return Err(EngineError::UnsupportedAnsiSequence(sequence.to_string()));
@@ -255,7 +277,16 @@ impl<'a> Preprocessor<'a> {
                             let code = parameters[idx + 2];
                             let color = xterm_color(code)?;
                             idx += 2;
-                            (format!("\x1b[{selector};5;{code}m"), color)
+                            #[cfg(not(target_arch = "wasm32"))]
+                            {
+                                let seq = format!("\x1b[{parameter};5;{code}m");
+                                if is_fg {
+                                    state.fg_sequence = seq;
+                                } else {
+                                    state.bg_sequence = seq;
+                                }
+                            }
+                            color
                         }
                         2 => {
                             if idx + 4 >= parameters.len() {
@@ -263,18 +294,25 @@ impl<'a> Preprocessor<'a> {
                             }
                             let hex: String = (2..5).map(|o| format!("{:02X}", parameters[idx + o])).collect();
                             let color = Color::from_hex(&hex).map_err(EngineError::Other)?;
-                            let (r, g, b) = color.rgb_ints();
                             idx += 4;
-                            (format!("\x1b[{selector};2;{r};{g};{b}m"), color)
+                            #[cfg(not(target_arch = "wasm32"))]
+                            {
+                                let (r, g, b) = color.rgb_ints();
+                                let seq = format!("\x1b[{parameter};2;{r};{g};{b}m");
+                                if is_fg {
+                                    state.fg_sequence = seq;
+                                } else {
+                                    state.bg_sequence = seq;
+                                }
+                            }
+                            color
                         }
                         _ => return Err(EngineError::UnsupportedAnsiSequence(sequence.to_string())),
                     };
                     if is_fg {
-                        state.fg_sequence = normalized_sequence;
                         state.fg_color = Some(color);
                         state.standard_fg_parameter = None;
                     } else {
-                        state.bg_sequence = normalized_sequence;
                         state.bg_color = Some(color);
                     }
                 }

--- a/src/engine/motion.rs
+++ b/src/engine/motion.rs
@@ -75,7 +75,7 @@ impl Path {
         loop_: bool,
     ) -> Result<Self, String> {
         if speed <= 0.0 {
-            return Err(format!("Path speed must be greater than 0. Received: {speed}"));
+            return Err("Path speed must be greater than 0.".to_string());
         }
         Ok(Path {
             path_id: path_id.to_string(),

--- a/src/engine/terminal.rs
+++ b/src/engine/terminal.rs
@@ -36,6 +36,8 @@ pub struct TerminalConfig {
     pub reuse_canvas: bool,
     pub no_eol: bool,
     pub no_restore_cursor: bool,
+    /// When set, skip tty/`COLUMNS`/`LINES` probing and use this size.
+    pub terminal_size: Option<(i64, i64)>,
 }
 
 impl Default for TerminalConfig {
@@ -56,6 +58,7 @@ impl Default for TerminalConfig {
             reuse_canvas: false,
             no_eol: false,
             no_restore_cursor: false,
+            terminal_size: None,
         }
     }
 }
@@ -140,7 +143,8 @@ pub struct Terminal {
     output_buffer: String,
     move_cursor_to_top: String,
     frame_rate: i64,
-    last_time_printed: Instant,
+    #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
+    last_time_printed: Option<Instant>,
 }
 
 fn ordered_buckets(
@@ -186,7 +190,7 @@ impl Terminal {
         .preprocess(input_data)?;
 
         let input_line_lengths: Vec<i64> = preprocessed_lines.iter().map(|l| l.len() as i64).collect();
-        let terminal_dimensions = get_terminal_dimensions();
+        let terminal_dimensions = get_terminal_dimensions(&config);
         let layout = compute_layout(&config, &input_line_lengths, terminal_dimensions.0, terminal_dimensions.1);
         let mut canvas = Canvas::new(layout.canvas_height, layout.canvas_width);
         let Layout {
@@ -248,7 +252,16 @@ impl Terminal {
             output_buffer: String::new(),
             move_cursor_to_top,
             frame_rate,
-            last_time_printed: Instant::now(),
+            last_time_printed: {
+                #[cfg(target_arch = "wasm32")]
+                {
+                    None
+                }
+                #[cfg(not(target_arch = "wasm32"))]
+                {
+                    Some(Instant::now())
+                }
+            },
         };
         terminal.make_fill_characters();
         terminal.setup_character_neighbors();
@@ -632,7 +645,7 @@ impl Terminal {
         if self.config.ignore_terminal_dimensions {
             return false;
         }
-        let (width, height) = get_terminal_dimensions();
+        let (width, height) = get_terminal_dimensions(&self.config);
         if (width, height) == self.terminal_dimensions {
             return false;
         }
@@ -692,32 +705,141 @@ impl Terminal {
         if self.frame_rate == 0 {
             return;
         }
-        let frame_delay = 1.0 / self.frame_rate as f64;
-        let elapsed = self.last_time_printed.elapsed().as_secs_f64();
-        if elapsed < frame_delay {
-            std::thread::sleep(std::time::Duration::from_secs_f64(frame_delay - elapsed));
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let frame_delay = 1.0 / self.frame_rate as f64;
+            let elapsed = self
+                .last_time_printed
+                .map(|t| t.elapsed().as_secs_f64())
+                .unwrap_or(0.0);
+            if elapsed < frame_delay {
+                std::thread::sleep(std::time::Duration::from_secs_f64(frame_delay - elapsed));
+            }
+            self.last_time_printed = Some(Instant::now());
         }
-        self.last_time_printed = Instant::now();
+    }
+
+    /// Display-order cell buffer (top-left first) for non-ANSI frontends.
+    pub fn pack_display_frame(&mut self) -> PackedFrame {
+        let (width, height) = self.update_render_cells();
+        let cells = width.saturating_mul(height);
+        let mut symbols = String::with_capacity(cells);
+        let mut fg = Vec::with_capacity(cells);
+        let mut bg = Vec::with_capacity(cells);
+        let mut flags = Vec::with_capacity(cells);
+        let arena = &self.arena;
+        for row_index in (0..height).rev() {
+            for &cell in &self.render_cells[row_index * width..(row_index + 1) * width] {
+                if cell == EMPTY_RENDER_CELL {
+                    symbols.push(' ');
+                    fg.push(0);
+                    bg.push(0);
+                    flags.push(0);
+                    continue;
+                }
+                let visual = &arena[cell as usize].animation.current_character_visual;
+                let ch = visual.symbol.chars().next().unwrap_or(' ');
+                symbols.push(if visual.hidden { ' ' } else { ch });
+                let mut cell_fg = visual
+                    .fg_color_code
+                    .as_ref()
+                    .map(crate::utils::ansi::ColorCode::rgb_u32)
+                    .unwrap_or(0);
+                let mut cell_bg = visual
+                    .bg_color_code
+                    .as_ref()
+                    .map(crate::utils::ansi::ColorCode::rgb_u32)
+                    .unwrap_or(0);
+                if visual.reverse {
+                    if cell_fg == 0 {
+                        cell_fg = 0xFFC0C0C0;
+                    }
+                    if cell_bg == 0 {
+                        cell_bg = 0xFF000000;
+                    }
+                    std::mem::swap(&mut cell_fg, &mut cell_bg);
+                }
+                let mut cell_flags = 0u8;
+                if visual.bold {
+                    cell_flags |= PackedFrame::BOLD;
+                }
+                if visual.italic {
+                    cell_flags |= PackedFrame::ITALIC;
+                }
+                if visual.underline {
+                    cell_flags |= PackedFrame::UNDERLINE;
+                }
+                if visual.reverse {
+                    cell_flags |= PackedFrame::REVERSE;
+                }
+                if visual.blink {
+                    cell_flags |= PackedFrame::BLINK;
+                }
+                if visual.hidden {
+                    cell_flags |= PackedFrame::HIDDEN;
+                }
+                if visual.strike {
+                    cell_flags |= PackedFrame::STRIKE;
+                }
+                fg.push(cell_fg);
+                bg.push(cell_bg);
+                flags.push(cell_flags);
+            }
+        }
+        PackedFrame {
+            width,
+            height,
+            symbols,
+            fg,
+            bg,
+            flags,
+        }
     }
 }
 
+/// One rendered frame as parallel arrays, display-order, one Unicode scalar per cell.
+#[derive(Debug, Clone)]
+pub struct PackedFrame {
+    pub width: usize,
+    pub height: usize,
+    pub symbols: String,
+    pub fg: Vec<u32>,
+    pub bg: Vec<u32>,
+    pub flags: Vec<u8>,
+}
+
+impl PackedFrame {
+    pub const BOLD: u8 = 1;
+    pub const ITALIC: u8 = 2;
+    pub const UNDERLINE: u8 = 4;
+    pub const REVERSE: u8 = 8;
+    pub const BLINK: u8 = 16;
+    pub const HIDDEN: u8 = 32;
+    pub const STRIKE: u8 = 64;
+}
+
 /// shutil.get_terminal_size semantics: COLUMNS/LINES env vars win; else query
-/// the tty; on failure (80, 24).
-fn get_terminal_dimensions() -> (i64, i64) {
-    let env_dim = |name: &str| -> Option<i64> {
-        std::env::var(name).ok()?.parse::<i64>().ok()
-    };
+/// the tty; on failure (80, 24). `TerminalConfig::terminal_size` wins over all.
+fn get_terminal_dimensions(config: &TerminalConfig) -> (i64, i64) {
+    if let Some(size) = config.terminal_size {
+        return size;
+    }
+    let env_dim = |name: &str| -> Option<i64> { std::env::var(name).ok()?.parse::<i64>().ok() };
     let columns = env_dim("COLUMNS");
     let lines = env_dim("LINES");
     if let (Some(c), Some(l)) = (columns, lines) {
         return (c, l);
     }
-    match terminal_size::terminal_size() {
-        Some((terminal_size::Width(w), terminal_size::Height(h))) => {
-            (columns.unwrap_or(w as i64), lines.unwrap_or(h as i64))
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        match terminal_size::terminal_size() {
+            Some((terminal_size::Width(w), terminal_size::Height(h))) => {
+                return (columns.unwrap_or(w as i64), lines.unwrap_or(h as i64));
+            }
+            None => {}
         }
-        None => (columns.unwrap_or(80), lines.unwrap_or(24)),
     }
+    (columns.unwrap_or(80), lines.unwrap_or(24))
 }
 
 /// Everything about the drawing area that is derived from the terminal size.

--- a/src/engine/terminal.rs
+++ b/src/engine/terminal.rs
@@ -756,11 +756,24 @@ impl Terminal {
                 let visual = &arena[cell as usize].animation.current_character_visual;
                 let ch = visual.symbol.chars().next().unwrap_or(' ');
                 symbols.push(if visual.hidden { b' ' as u32 } else { ch as u32 });
+                // Wasm Session never sets xterm_colors or no_color; packed cells
+                // already have 24-bit RGB on Color, so skip the ColorCode hex
+                // round-trip (to_string + parse) that native SGR still needs.
+                #[cfg(target_arch = "wasm32")]
+                let (mut cell_fg, mut cell_bg) = {
+                    let pair = visual.colors.as_ref();
+                    (
+                        packed_rgba(pair.and_then(|p| p.fg_color.as_ref())),
+                        packed_rgba(pair.and_then(|p| p.bg_color.as_ref())),
+                    )
+                };
+                #[cfg(not(target_arch = "wasm32"))]
                 let mut cell_fg = visual
                     .fg_color_code
                     .as_ref()
                     .map(crate::utils::ansi::ColorCode::rgb_u32)
                     .unwrap_or(0);
+                #[cfg(not(target_arch = "wasm32"))]
                 let mut cell_bg = visual
                     .bg_color_code
                     .as_ref()
@@ -811,6 +824,15 @@ impl Terminal {
             flags,
         }
     }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn packed_rgba(color: Option<&Color>) -> u32 {
+    let Some(color) = color else {
+        return 0;
+    };
+    let (r, g, b) = color.rgb_ints();
+    0xFF000000 | ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
 }
 
 /// One rendered frame as parallel arrays, display-order, one Unicode scalar per cell.

--- a/src/engine/terminal.rs
+++ b/src/engine/terminal.rs
@@ -3,7 +3,9 @@
 //! per run), this single Terminal owns both the simulation and the tty side.
 
 use std::collections::HashMap;
+#[cfg(not(target_arch = "wasm32"))]
 use std::io::Write;
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::Instant;
 
 use crate::engine::animation::ExistingColorHandling;
@@ -11,6 +13,7 @@ use crate::engine::canvas::{Anchor, Canvas};
 use crate::engine::character::{CharId, EffectCharacter};
 use crate::engine::error::EngineError;
 use crate::engine::input::{ColorFrequency, Preprocessor};
+#[cfg(not(target_arch = "wasm32"))]
 use crate::utils::ansi;
 use crate::utils::geometry::Coord;
 use crate::utils::graphics::Color;
@@ -119,11 +122,15 @@ pub struct Terminal {
     pub arena: Vec<EffectCharacter>,
     next_character_id: u32,
     pub input_colors_frequency: ColorFrequency,
+    #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
     terminal_dimensions: (i64, i64),
+    #[cfg(not(target_arch = "wasm32"))]
     resize_seen_at: Option<Instant>,
+    #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
     layout: Layout,
     /// Pre-wrap input line lengths — all `compute_layout` needs from the input,
     /// so a resize can re-derive the geometry without re-preprocessing.
+    #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
     input_line_lengths: Vec<i64>,
     pub canvas_column_offset: i64,
     pub canvas_row_offset: i64,
@@ -139,11 +146,15 @@ pub struct Terminal {
     visible_characters: Vec<CharId>,
     visible_positions: Vec<usize>,
     render_cells: Vec<u32>,
+    #[cfg(not(target_arch = "wasm32"))]
     pub terminal_state: Vec<String>,
+    #[cfg(not(target_arch = "wasm32"))]
     output_buffer: String,
+    #[cfg(not(target_arch = "wasm32"))]
     move_cursor_to_top: String,
-    frame_rate: i64,
     #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
+    frame_rate: i64,
+    #[cfg(not(target_arch = "wasm32"))]
     last_time_printed: Option<Instant>,
 }
 
@@ -218,6 +229,7 @@ impl Terminal {
 
         let frame_rate = config.frame_rate;
         let arena_len = arena.len();
+        #[cfg(not(target_arch = "wasm32"))]
         let move_cursor_to_top = format!(
             "{}{}{}",
             ansi::DEC_RESTORE_CURSOR,
@@ -231,6 +243,7 @@ impl Terminal {
             next_character_id,
             input_colors_frequency,
             terminal_dimensions,
+            #[cfg(not(target_arch = "wasm32"))]
             resize_seen_at: None,
             layout,
             input_line_lengths,
@@ -248,23 +261,19 @@ impl Terminal {
             visible_characters: Vec::new(),
             visible_positions: vec![NOT_VISIBLE; arena_len],
             render_cells: Vec::new(),
+            #[cfg(not(target_arch = "wasm32"))]
             terminal_state: Vec::new(),
+            #[cfg(not(target_arch = "wasm32"))]
             output_buffer: String::new(),
+            #[cfg(not(target_arch = "wasm32"))]
             move_cursor_to_top,
             frame_rate,
-            last_time_printed: {
-                #[cfg(target_arch = "wasm32")]
-                {
-                    None
-                }
-                #[cfg(not(target_arch = "wasm32"))]
-                {
-                    Some(Instant::now())
-                }
-            },
+            #[cfg(not(target_arch = "wasm32"))]
+            last_time_printed: Some(Instant::now()),
         };
         terminal.make_fill_characters();
         terminal.setup_character_neighbors();
+        #[cfg(not(target_arch = "wasm32"))]
         terminal.update_terminal_state();
         Ok(terminal)
     }
@@ -564,6 +573,7 @@ impl Terminal {
     /// Terminal._update_terminal_state: materialize the row-oriented state
     /// exposed by the upstream API. Frame output uses the cell buffer directly
     /// so the hot path does not copy every rendered byte through these rows.
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn update_terminal_state(&mut self) {
         let (width, height) = self.update_render_cells();
 
@@ -586,6 +596,7 @@ impl Terminal {
     }
 
     /// get_formatted_output_string: refresh + emit top row first.
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn get_formatted_output_string(&mut self) -> String {
         let (width, height) = self.update_render_cells();
         let minimum_capacity = width
@@ -614,6 +625,7 @@ impl Terminal {
         unsafe { String::from_utf8_unchecked(out) }
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) fn recycle_output_string(&mut self, mut output: String) {
         output.clear();
         if output.capacity() > self.output_buffer.capacity() {
@@ -632,6 +644,7 @@ impl Terminal {
     /// canvas and no anchor offsets most resizes leave every rendered cell
     /// exactly where it was, and restarting for those is pure loss. Explicitly
     /// ignored dimensions are fixed by definition.
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn resize_settled(&mut self) -> bool {
         const QUIET: std::time::Duration = std::time::Duration::from_millis(50);
 
@@ -655,6 +668,7 @@ impl Terminal {
     /// After a resize: go back to the top of the area this run allocated, wipe
     /// it, and leave the cursor there so the rebuilt canvas takes the same rows
     /// instead of scrolling a second one into the terminal.
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn reset_canvas_area(&self, out: &mut impl Write) -> std::io::Result<()> {
         out.write_all(ansi::DEC_RESTORE_CURSOR.as_bytes())?;
         if self.visible_top > 0 {
@@ -666,6 +680,7 @@ impl Terminal {
 
     // --- tty side (upstream's second Terminal instance) ---
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn prep_canvas(&mut self, out: &mut impl Write) -> std::io::Result<()> {
         out.write_all(ansi::HIDE_CURSOR.as_bytes())?;
         if self.config.reuse_canvas {
@@ -680,6 +695,7 @@ impl Terminal {
         Ok(())
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn restore_cursor(&self, out: &mut impl Write, end_symbol: &str) -> std::io::Result<()> {
         let end_symbol = if self.config.no_eol { "" } else { end_symbol };
         if !self.config.no_restore_cursor {
@@ -689,34 +705,34 @@ impl Terminal {
         Ok(())
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn print_frame(&mut self, out: &mut impl Write, output_string: &str) -> std::io::Result<()> {
         self.write_move_cursor_to_top(out)?;
         out.write_all(output_string.as_bytes())?;
         out.flush()
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     fn write_move_cursor_to_top(&self, out: &mut impl Write) -> std::io::Result<()> {
         out.write_all(self.move_cursor_to_top.as_bytes())
     }
 
     /// Terminal.enforce_framerate: sleep off the remainder; timestamp taken
     /// AFTER the sleep (drift accumulates, faithfully).
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn enforce_framerate(&mut self) {
         if self.frame_rate == 0 {
             return;
         }
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            let frame_delay = 1.0 / self.frame_rate as f64;
-            let elapsed = self
-                .last_time_printed
-                .map(|t| t.elapsed().as_secs_f64())
-                .unwrap_or(0.0);
-            if elapsed < frame_delay {
-                std::thread::sleep(std::time::Duration::from_secs_f64(frame_delay - elapsed));
-            }
-            self.last_time_printed = Some(Instant::now());
+        let frame_delay = 1.0 / self.frame_rate as f64;
+        let elapsed = self
+            .last_time_printed
+            .map(|t| t.elapsed().as_secs_f64())
+            .unwrap_or(0.0);
+        if elapsed < frame_delay {
+            std::thread::sleep(std::time::Duration::from_secs_f64(frame_delay - elapsed));
         }
+        self.last_time_printed = Some(Instant::now());
     }
 
     /// Display-order cell buffer (top-left first) for non-ANSI frontends.

--- a/src/engine/terminal.rs
+++ b/src/engine/terminal.rs
@@ -723,7 +723,7 @@ impl Terminal {
     pub fn pack_display_frame(&mut self) -> PackedFrame {
         let (width, height) = self.update_render_cells();
         let cells = width.saturating_mul(height);
-        let mut symbols = String::with_capacity(cells);
+        let mut symbols = Vec::with_capacity(cells);
         let mut fg = Vec::with_capacity(cells);
         let mut bg = Vec::with_capacity(cells);
         let mut flags = Vec::with_capacity(cells);
@@ -731,7 +731,7 @@ impl Terminal {
         for row_index in (0..height).rev() {
             for &cell in &self.render_cells[row_index * width..(row_index + 1) * width] {
                 if cell == EMPTY_RENDER_CELL {
-                    symbols.push(' ');
+                    symbols.push(b' ' as u32);
                     fg.push(0);
                     bg.push(0);
                     flags.push(0);
@@ -739,7 +739,7 @@ impl Terminal {
                 }
                 let visual = &arena[cell as usize].animation.current_character_visual;
                 let ch = visual.symbol.chars().next().unwrap_or(' ');
-                symbols.push(if visual.hidden { ' ' } else { ch });
+                symbols.push(if visual.hidden { b' ' as u32 } else { ch as u32 });
                 let mut cell_fg = visual
                     .fg_color_code
                     .as_ref()
@@ -802,7 +802,7 @@ impl Terminal {
 pub struct PackedFrame {
     pub width: usize,
     pub height: usize,
-    pub symbols: String,
+    pub symbols: Vec<u32>,
     pub fg: Vec<u32>,
     pub bg: Vec<u32>,
     pub flags: Vec<u8>,
@@ -816,6 +816,33 @@ impl PackedFrame {
     pub const BLINK: u8 = 16;
     pub const HIDDEN: u8 = 32;
     pub const STRIKE: u8 = 64;
+
+    pub fn cell_count(&self) -> usize {
+        self.width.saturating_mul(self.height)
+    }
+
+    /// Copy this frame into caller-owned buffers. Extra capacity is left untouched.
+    pub fn fill(
+        &self,
+        symbols: &mut [u32],
+        fg: &mut [u32],
+        bg: &mut [u32],
+        flags: &mut [u8],
+    ) -> Result<usize, &'static str> {
+        let n = self.cell_count();
+        if self.symbols.len() != n || self.fg.len() != n || self.bg.len() != n || self.flags.len() != n
+        {
+            return Err("packed frame is truncated");
+        }
+        if symbols.len() < n || fg.len() < n || bg.len() < n || flags.len() < n {
+            return Err("frame buffers are too small");
+        }
+        symbols[..n].copy_from_slice(&self.symbols);
+        fg[..n].copy_from_slice(&self.fg);
+        bg[..n].copy_from_slice(&self.bg);
+        flags[..n].copy_from_slice(&self.flags);
+        Ok(n)
+    }
 }
 
 /// shutil.get_terminal_size semantics: COLUMNS/LINES env vars win; else query

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#[cfg(not(target_arch = "wasm32"))]
 pub mod cli;
 pub mod effects;
 pub mod engine;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,10 @@ pub mod effects;
 pub mod engine;
 pub mod utils;
 
+#[cfg(target_arch = "wasm32")]
+pub mod wasm;
+
+#[cfg(not(target_arch = "wasm32"))]
 use std::sync::atomic::{AtomicBool, Ordering};
 
 /// `println!` and `eprintln!` panic when their write fails, and a release
@@ -37,13 +41,32 @@ macro_rules! errln {
     }};
 }
 
+#[cfg(target_arch = "wasm32")]
+pub fn interrupted() -> bool {
+    false
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn terminated() -> bool {
+    false
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn take_terminal_resize() -> bool {
+    false
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 static INTERRUPTED: AtomicBool = AtomicBool::new(false);
+#[cfg(not(target_arch = "wasm32"))]
 static TERMINATED: AtomicBool = AtomicBool::new(false);
+#[cfg(not(target_arch = "wasm32"))]
 static TERMINAL_RESIZED: AtomicBool = AtomicBool::new(false);
 
 /// SIGINT is recorded and checked from the run loop so teardown (cursor
 /// restore) happens through normal control flow — Drop alone would not run on
 /// a raw signal exit (plan.md §8).
+#[cfg(not(target_arch = "wasm32"))]
 pub fn install_sigint_handler() {
     // SAFETY: signal(2) with a signal-safe handler that only stores a flag.
     unsafe {
@@ -51,10 +74,12 @@ pub fn install_sigint_handler() {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 extern "C" fn handle_sigint(_: i32) {
     INTERRUPTED.store(true, Ordering::SeqCst);
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub fn interrupted() -> bool {
     INTERRUPTED.load(Ordering::SeqCst)
 }
@@ -62,6 +87,7 @@ pub fn interrupted() -> bool {
 /// SIGTERM is recorded like SIGINT so a supervisor killing an animation gets
 /// the normal teardown instead of a hidden cursor. `die_from_sigterm` then
 /// finishes the job the handler deferred.
+#[cfg(not(target_arch = "wasm32"))]
 pub fn install_sigterm_handler() {
     // SAFETY: signal(2) with a signal-safe handler that only stores a flag.
     unsafe {
@@ -69,10 +95,12 @@ pub fn install_sigterm_handler() {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 extern "C" fn handle_sigterm(_: i32) {
     TERMINATED.store(true, Ordering::SeqCst);
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub fn terminated() -> bool {
     TERMINATED.load(Ordering::SeqCst)
 }
@@ -82,6 +110,7 @@ pub fn terminated() -> bool {
 /// child, exactly as it would from the redirected run that never installs a
 /// handler at all. SIGINT does not go through here — upstream exits 1 on
 /// KeyboardInterrupt and parity outranks the convention (plan.md §8).
+#[cfg(not(target_arch = "wasm32"))]
 pub fn die_from_sigterm() -> ! {
     // SAFETY: restoring the default action and re-raising is the documented
     // way to exit with a signal's status; raise(2) here does not return.
@@ -94,6 +123,7 @@ pub fn die_from_sigterm() -> ! {
 
 /// Record terminal resizes so the CLI can rebuild effects whose canvas and
 /// character positions were derived from the previous dimensions.
+#[cfg(not(target_arch = "wasm32"))]
 pub fn install_sigwinch_handler() {
     // SAFETY: signal(2) with a signal-safe handler that only stores a flag.
     unsafe {
@@ -101,30 +131,39 @@ pub fn install_sigwinch_handler() {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 extern "C" fn handle_sigwinch(_: i32) {
     TERMINAL_RESIZED.store(true, Ordering::SeqCst);
 }
 
 /// Consume a pending terminal resize notification.
+#[cfg(not(target_arch = "wasm32"))]
 pub fn take_terminal_resize() -> bool {
     TERMINAL_RESIZED.swap(false, Ordering::SeqCst)
 }
 
 /// Restore default SIGPIPE so `ttfx ... | head` dies quietly like any Unix
 /// tool instead of panicking on a broken pipe (Rust ignores SIGPIPE by default).
+#[cfg(not(target_arch = "wasm32"))]
 pub fn restore_sigpipe() {
     unsafe {
         libc_signal(SIGPIPE, SIG_DFL);
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 const SIGINT: i32 = 2;
+#[cfg(not(target_arch = "wasm32"))]
 const SIGTERM: i32 = 15;
+#[cfg(not(target_arch = "wasm32"))]
 const SIGPIPE: i32 = 13;
 /// 28 on Linux and on the BSDs, macOS included.
+#[cfg(not(target_arch = "wasm32"))]
 const SIGWINCH: i32 = 28;
+#[cfg(not(target_arch = "wasm32"))]
 const SIG_DFL: usize = 0;
 
+#[cfg(not(target_arch = "wasm32"))]
 unsafe fn libc_signal(signum: i32, handler: usize) {
     unsafe extern "C" {
         fn signal(signum: i32, handler: usize) -> usize;
@@ -134,6 +173,7 @@ unsafe fn libc_signal(signum: i32, handler: usize) {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 unsafe fn libc_raise(signum: i32) {
     unsafe extern "C" {
         fn raise(signum: i32) -> i32;

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,6 +138,13 @@ fn main() -> ExitCode {
     }
 
     let mut config = cli.terminal_config();
+    if cli.bands {
+        if cli.palette().is_none() {
+            ttfx::errln!("Error: --bands requires --palette.");
+            return ExitCode::from(1);
+        }
+        config.existing_color_handling = ttfx::engine::animation::ExistingColorHandling::Always;
+    }
     // SIGWINCH is delivered to every process in the terminal's foreground group,
     // whatever its stdout points at. Reacting to it when the animation is being
     // redirected would leave a truncated first run followed by a complete second
@@ -171,6 +178,12 @@ fn main() -> ExitCode {
                     return ExitCode::from(1);
                 }
             };
+        if cli.bands {
+            if let Some(palette) = cli.palette() {
+                ttfx::utils::bands::apply_field_bands(&mut ctx.terminal, &palette);
+                ctx.preexisting_colors_present = true;
+            }
+        }
         let mut effect = effect_command.build_effect();
 
         let outcome = if cli.parity_dump {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,11 @@
+use std::collections::HashSet;
 use std::io::{IsTerminal, Read};
 use std::process::ExitCode;
 
-use clap::Parser;
+use clap::{CommandFactory, FromArgMatches};
 
 use ttfx::engine::terminal::Terminal;
+use ttfx::utils::palette::command_line_arg_ids;
 use ttfx::{cli, engine};
 
 fn get_piped_input() -> String {
@@ -39,7 +41,8 @@ fn forget_engine<E, C>(effect: E, ctx: C) {
 
 fn main() -> ExitCode {
     ttfx::restore_sigpipe();
-    let cli = cli::Cli::parse();
+    let matches = cli::Cli::command().get_matches();
+    let cli = cli::Cli::from_arg_matches(&matches).unwrap_or_else(|e| e.exit());
 
     // upstream prints the completion script and returns before any input handling
     if let Some(shell) = &cli.print_completion {
@@ -87,9 +90,8 @@ fn main() -> ExitCode {
 
     // --random-effect: pick from the registry (filtered), run with pure
     // default effect config — upstream ignores effect CLI args here too.
-    let chosen_effect;
-    let effect_command = if cli.random_effect {
-        use clap::CommandFactory;
+    // --palette still applies; there are no effect color flags to keep.
+    let mut effect_command = if cli.random_effect {
         let mut names: Vec<String> = cli::Cli::command()
             .get_subcommands()
             .map(|c| c.get_name().to_string())
@@ -103,16 +105,18 @@ fn main() -> ExitCode {
             return ExitCode::from(1);
         }
         let name = names[rng.choice_index(names.len())].clone();
-        chosen_effect = match clap::Parser::try_parse_from::<_, &str>(["ttfx", &name]) {
-            Ok(cli::Cli { effect: Some(effect), .. }) => effect,
+        match clap::Parser::try_parse_from::<_, &str>(["ttfx", &name]) {
+            Ok(cli::Cli {
+                effect: Some(effect),
+                ..
+            }) => effect,
             _ => {
                 ttfx::errln!("Error: failed to build effect '{name}'.");
                 return ExitCode::from(1);
             }
-        };
-        &chosen_effect
+        }
     } else {
-        match &cli.effect {
+        match cli.effect.clone() {
             Some(effect) => effect,
             None => {
                 ttfx::errln!("Error: No effect specified.");
@@ -120,6 +124,18 @@ fn main() -> ExitCode {
             }
         }
     };
+
+    if let Some(palette) = cli.palette() {
+        let skip = if cli.random_effect {
+            HashSet::new()
+        } else {
+            matches
+                .subcommand()
+                .map(|(_, sub)| command_line_arg_ids(sub))
+                .unwrap_or_default()
+        };
+        effect_command.apply_palette(&palette, &skip);
+    }
 
     let mut config = cli.terminal_config();
     // SIGWINCH is delivered to every process in the terminal's foreground group,
@@ -143,22 +159,18 @@ fn main() -> ExitCode {
         } else {
             ttfx::engine::ctx::Clock::real()
         };
-        let mut ctx = match ttfx::engine::ctx::EngineCtx::new(
-            &input_data,
-            config.clone(),
-            rng,
-            clock,
-        ) {
-            Ok(ctx) => ctx,
-            Err(engine::error::EngineError::UnsupportedAnsiSequence(seq)) => {
-                ttfx::errln!("Error: Unsupported ANSI sequence in input data: {seq:?}");
-                return ExitCode::from(1);
-            }
-            Err(e) => {
-                ttfx::errln!("Error: {e}");
-                return ExitCode::from(1);
-            }
-        };
+        let mut ctx =
+            match ttfx::engine::ctx::EngineCtx::new(&input_data, config.clone(), rng, clock) {
+                Ok(ctx) => ctx,
+                Err(engine::error::EngineError::UnsupportedAnsiSequence(seq)) => {
+                    ttfx::errln!("Error: Unsupported ANSI sequence in input data: {seq:?}");
+                    return ExitCode::from(1);
+                }
+                Err(e) => {
+                    ttfx::errln!("Error: {e}");
+                    return ExitCode::from(1);
+                }
+            };
         let mut effect = effect_command.build_effect();
 
         let outcome = if cli.parity_dump {
@@ -218,7 +230,11 @@ fn m0_dump(input_data: &str, cli: &cli::Cli) -> ExitCode {
             return ExitCode::from(1);
         }
     };
-    let ids: Vec<_> = terminal.character_by_input_coord.values().copied().collect();
+    let ids: Vec<_> = terminal
+        .character_by_input_coord
+        .values()
+        .copied()
+        .collect();
     for id in ids {
         terminal.set_character_visibility(id, true);
     }

--- a/src/utils/ansi.rs
+++ b/src/utils/ansi.rs
@@ -62,12 +62,8 @@ impl ColorCode {
                 )
             }
             ColorCode::Xterm(n) => {
-                let s = crate::utils::hexterm::xterm_to_hex(*n);
-                (
-                    u8::from_str_radix(&s[0..2], 16).unwrap_or(0),
-                    u8::from_str_radix(&s[2..4], 16).unwrap_or(0),
-                    u8::from_str_radix(&s[4..6], 16).unwrap_or(0),
-                )
+                let [r, g, b] = crate::utils::hexterm::xterm_rgb(*n);
+                (r, g, b)
             }
         };
         0xFF000000 | ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)

--- a/src/utils/ansi.rs
+++ b/src/utils/ansi.rs
@@ -2,25 +2,41 @@
 
 use std::fmt::Write;
 
+#[cfg(not(target_arch = "wasm32"))]
 pub const DEC_SAVE_CURSOR: &str = "\x1b7";
+#[cfg(not(target_arch = "wasm32"))]
 pub const DEC_RESTORE_CURSOR: &str = "\x1b8";
+#[cfg(not(target_arch = "wasm32"))]
 pub const HIDE_CURSOR: &str = "\x1b[?25l";
+#[cfg(not(target_arch = "wasm32"))]
 pub const SHOW_CURSOR: &str = "\x1b[?25h";
+#[cfg(not(target_arch = "wasm32"))]
 pub const RESET_ALL: &str = "\x1b[0m";
+#[cfg(not(target_arch = "wasm32"))]
 pub const CLEAR_TO_END_OF_SCREEN: &str = "\x1b[0J";
+#[cfg(not(target_arch = "wasm32"))]
 pub const BOLD: &str = "\x1b[1m";
+#[cfg(not(target_arch = "wasm32"))]
 pub const DIM: &str = "\x1b[2m";
+#[cfg(not(target_arch = "wasm32"))]
 pub const ITALIC: &str = "\x1b[3m";
+#[cfg(not(target_arch = "wasm32"))]
 pub const UNDERLINE: &str = "\x1b[4m";
+#[cfg(not(target_arch = "wasm32"))]
 pub const BLINK: &str = "\x1b[5m";
+#[cfg(not(target_arch = "wasm32"))]
 pub const REVERSE: &str = "\x1b[7m";
+#[cfg(not(target_arch = "wasm32"))]
 pub const HIDDEN: &str = "\x1b[8m";
+#[cfg(not(target_arch = "wasm32"))]
 pub const STRIKETHROUGH: &str = "\x1b[9m";
 
+#[cfg(not(target_arch = "wasm32"))]
 pub fn move_cursor_up(y: usize) -> String {
     format!("\x1b[{y}A")
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub fn move_cursor_to_column(x: usize) -> String {
     format!("\x1b[{x}G")
 }
@@ -61,6 +77,7 @@ impl ColorCode {
 /// Decimal digits of a byte, without going through core::fmt. Every restyled
 /// character reassembles its SGR sequence, so the formatting machinery shows up
 /// in profiles.
+#[cfg(not(target_arch = "wasm32"))]
 #[inline]
 fn push_decimal(out: &mut String, value: u8) {
     if value >= 100 {
@@ -73,6 +90,7 @@ fn push_decimal(out: &mut String, value: u8) {
 }
 
 /// colorterm._color: fg selector 38, bg selector 48.
+#[cfg(not(target_arch = "wasm32"))]
 fn sgr_color(code: &ColorCode, location: u8, out: &mut String) {
     out.push_str("\x1b[");
     push_decimal(out, location);
@@ -97,10 +115,12 @@ fn sgr_color(code: &ColorCode, location: u8, out: &mut String) {
     out.push('m');
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub fn fg(code: &ColorCode, out: &mut String) {
     sgr_color(code, 38, out);
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub fn bg(code: &ColorCode, out: &mut String) {
     sgr_color(code, 48, out);
 }

--- a/src/utils/ansi.rs
+++ b/src/utils/ansi.rs
@@ -33,6 +33,31 @@ pub enum ColorCode {
     Xterm(u8),
 }
 
+impl ColorCode {
+    /// Packed 0xAARRGGBB with opaque alpha.
+    pub fn rgb_u32(&self) -> u32 {
+        let (r, g, b) = match self {
+            ColorCode::Rgb(hex) => {
+                let s = hex.trim_matches('#');
+                (
+                    u8::from_str_radix(&s[0..2], 16).unwrap_or(0),
+                    u8::from_str_radix(&s[2..4], 16).unwrap_or(0),
+                    u8::from_str_radix(&s[4..6], 16).unwrap_or(0),
+                )
+            }
+            ColorCode::Xterm(n) => {
+                let s = crate::utils::hexterm::xterm_to_hex(*n);
+                (
+                    u8::from_str_radix(&s[0..2], 16).unwrap_or(0),
+                    u8::from_str_radix(&s[2..4], 16).unwrap_or(0),
+                    u8::from_str_radix(&s[4..6], 16).unwrap_or(0),
+                )
+            }
+        };
+        0xFF000000 | ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
+    }
+}
+
 /// Decimal digits of a byte, without going through core::fmt. Every restyled
 /// character reassembles its SGR sequence, so the formatting machinery shows up
 /// in profiles.

--- a/src/utils/bands.rs
+++ b/src/utils/bands.rs
@@ -1,14 +1,15 @@
-//! Vertical field bands on the input word: 4, 1, 4, 3, 5 units crest to dim.
+//! Vertical field bands on the input word: 4, 3, 4, 3, 5 units crest to dim.
 //!
-//! The field is 17 units tall. `t` is 0 at the top of the word and 1 at the
-//! bottom. Palette color 0 is crest, then hover, lit, mid, dim.
+//! The field is 19 units tall, one per wordmark bitmap row. `t` is 0 at the
+//! top of the word and 1 at the bottom. Palette color 0 is crest, then hover,
+//! lit, mid, dim.
 
 use crate::engine::character::{CharId, EffectCharacter};
 use crate::engine::terminal::Terminal;
 use crate::utils::palette::Palette;
 
 /// Crest, hover, lit, mid, dim — top to bottom.
-pub const FIELD_BAND_UNITS: &[u32] = &[4, 1, 4, 3, 5];
+pub const FIELD_BAND_UNITS: &[u32] = &[4, 3, 4, 3, 5];
 
 pub fn field_band_rows() -> u32 {
     FIELD_BAND_UNITS.iter().sum()
@@ -102,7 +103,7 @@ pub fn field_band_index_n(i: u32, n: u32) -> usize {
 /// Color each input character from the palette by its row in the word.
 ///
 /// `input_coord.row` is 1-based and grows up, so the largest row is the top.
-/// 4-1-4-3-5 is laid out on the *body* rows (lines with at least half the
+/// 4-3-4-3-5 is laid out on the *body* rows (lines with at least half the
 /// ink of the densest line). The Omarchy FIGlet's M peak and Y tail are
 /// sparse; counting them in the span stole a crest row, so O/A/R only got
 /// a one-row cap. Sparse rows above the body stay crest; below stay dim.
@@ -166,19 +167,19 @@ mod tests {
     use super::*;
 
     #[test]
-    fn spec_units_are_four_one_four_three_five() {
-        assert_eq!(FIELD_BAND_UNITS, &[4, 1, 4, 3, 5]);
-        assert_eq!(field_band_rows(), 17);
+    fn spec_units_are_four_three_four_three_five() {
+        assert_eq!(FIELD_BAND_UNITS, &[4, 3, 4, 3, 5]);
+        assert_eq!(field_band_rows(), 19);
     }
 
     #[test]
     fn index_follows_crest_hover_lit_mid_dim() {
         assert_eq!(field_band_index(0.0), 0);
-        assert_eq!(field_band_index(4.0 / 17.0 - 1e-9), 0);
-        assert_eq!(field_band_index(4.0 / 17.0), 1);
-        assert_eq!(field_band_index(5.0 / 17.0), 2);
-        assert_eq!(field_band_index(9.0 / 17.0), 3);
-        assert_eq!(field_band_index(12.0 / 17.0), 4);
+        assert_eq!(field_band_index(4.0 / 19.0 - 1e-9), 0);
+        assert_eq!(field_band_index(4.0 / 19.0), 1);
+        assert_eq!(field_band_index(7.0 / 19.0), 2);
+        assert_eq!(field_band_index(11.0 / 19.0), 3);
+        assert_eq!(field_band_index(14.0 / 19.0), 4);
         assert_eq!(field_band_index(1.0), 4);
     }
 
@@ -212,8 +213,8 @@ mod tests {
             .collect();
         by_row.sort_by_key(|(row, _)| std::cmp::Reverse(*row));
 
-        // 4-1-4-3-5 on 13 rows is 3-1-3-2-4.
-        let expected = [0, 0, 0, 1, 2, 2, 2, 3, 3, 4, 4, 4, 4];
+        // 4-3-4-3-5 on 13 rows is 3-2-3-2-3.
+        let expected = [0, 0, 0, 1, 1, 2, 2, 2, 3, 3, 4, 4, 4];
         assert_eq!(by_row.len(), 13);
         for (i, (row, color)) in by_row.iter().enumerate() {
             assert_eq!(*row, 13 - i as i64);
@@ -254,7 +255,7 @@ mod tests {
             .collect();
         by_row.sort_by_key(|(row, _)| std::cmp::Reverse(*row));
 
-        let expected = [0, 0, 0, 0, 0, 1, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4, 4, 4, 4];
+        let expected = [0, 0, 0, 0, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4, 4, 4];
         assert_eq!(by_row.len(), 19);
         for (i, (row, idx)) in by_row.iter().enumerate() {
             assert_eq!(*row, 19 - i as i64);
@@ -264,9 +265,8 @@ mod tests {
 
     #[test]
     fn discrete_rows_never_drop_a_band() {
-        assert_eq!(field_band_counts(17), vec![4, 1, 4, 3, 5]);
-        assert_eq!(field_band_counts(13), vec![3, 1, 3, 2, 4]);
-        assert_eq!(field_band_counts(19), vec![5, 1, 4, 3, 6]);
+        assert_eq!(field_band_counts(19), vec![4, 3, 4, 3, 5]);
+        assert_eq!(field_band_counts(13), vec![3, 2, 3, 2, 3]);
         assert_eq!(field_band_counts(8), vec![2, 1, 2, 1, 2]);
         for n in 5..=40 {
             let counts = field_band_counts(n);
@@ -323,7 +323,7 @@ mod tests {
             .collect();
         by_row.sort_by_key(|(row, _)| std::cmp::Reverse(*row));
         let bands: Vec<usize> = by_row.into_iter().map(|(_, b)| b).collect();
-        // Sparse peak (row 0) and tail stay crest/dim; 4-1-4-3-5 is 2-1-2-1-2
+        // Sparse peak (row 0) and tail stay crest/dim; 4-3-4-3-5 is 2-1-2-1-2
         // on the 8 body rows, so the first two full letter rows are crest.
         assert_eq!(bands, vec![0, 0, 0, 1, 2, 2, 3, 4, 4, 4]);
     }

--- a/src/utils/bands.rs
+++ b/src/utils/bands.rs
@@ -35,67 +35,100 @@ pub fn field_band_index_in(t: f64, units: &[u32]) -> usize {
     units.len() - 1
 }
 
-/// Color each input character from the palette by its visual row in the word.
+/// How many of `n` discrete rows each band gets. Hamilton / largest remainder
+/// so a 1-unit hover is never dropped when `n` is not a multiple of 13.
+pub fn field_band_counts(n: u32) -> Vec<u32> {
+    let bands = FIELD_BAND_UNITS.len();
+    if n == 0 {
+        return vec![0; bands];
+    }
+    let total = field_band_rows() as f64;
+    let exact: Vec<f64> = FIELD_BAND_UNITS
+        .iter()
+        .map(|&u| n as f64 * u as f64 / total)
+        .collect();
+    let mut counts: Vec<u32> = exact.iter().map(|e| e.floor() as u32).collect();
+    let mut remain = n - counts.iter().sum::<u32>();
+    let mut order: Vec<usize> = (0..bands).collect();
+    order.sort_by(|&a, &b| {
+        exact[b]
+            .fract()
+            .partial_cmp(&exact[a].fract())
+            .unwrap()
+            .then(a.cmp(&b))
+    });
+    for i in order {
+        if remain == 0 {
+            break;
+        }
+        counts[i] += 1;
+        remain -= 1;
+    }
+    if n >= bands as u32 {
+        while let Some(zero) = counts.iter().position(|&c| c == 0) {
+            let Some(donor) = counts
+                .iter()
+                .enumerate()
+                .rev()
+                .find(|(_, &c)| c > 1)
+                .map(|(i, _)| i)
+            else {
+                break;
+            };
+            counts[donor] -= 1;
+            counts[zero] += 1;
+        }
+    }
+    counts
+}
+
+/// Band for discrete row `i` of `n` (0 at the top).
+pub fn field_band_index_n(i: u32, n: u32) -> usize {
+    if n == 0 {
+        return 0;
+    }
+    let i = i.min(n - 1);
+    let counts = field_band_counts(n);
+    let mut acc = 0u32;
+    for (b, &c) in counts.iter().enumerate() {
+        acc += c;
+        if i < acc {
+            return b;
+        }
+    }
+    counts.len() - 1
+}
+
+/// Color each input character from the palette by its row in the word.
 ///
 /// `input_coord.row` is 1-based and grows up, so the largest row is the top.
-/// Half-block art (`▄▀█`) encodes two spec pixels per terminal cell, the way
-/// the 19-row wordmark is stored in the screensaver logo. `t` is measured in
-/// those pixels so a full `█` is two units and a half block is one. Empty
-/// halves (the top of a leading `▄`, the bottom of a trailing `▀`) do not
-/// count, so the M peak cannot steal the crest from the other letters.
+/// Bands are laid out on whole terminal rows (3-1-3-2-4, largest remainder)
+/// so every stripe is visible. A `█` has one color; measuring in half-pixels
+/// lets the 1-unit hover fall between two cell centers and vanish.
 pub fn apply_field_bands(terminal: &mut Terminal, palette: &Palette) {
+    let mut min_row = i64::MAX;
     let mut max_row = i64::MIN;
-    let mut min_half = f64::INFINITY;
-    let mut max_half = f64::NEG_INFINITY;
     for &id in &terminal.input_characters {
         let ch = &terminal.arena[id.0 as usize];
         if skip_char(ch) {
             continue;
         }
+        min_row = min_row.min(ch.input_coord.row);
         max_row = max_row.max(ch.input_coord.row);
     }
-    if max_row == i64::MIN {
+    if min_row > max_row {
         return;
     }
-    for &id in &terminal.input_characters {
-        let ch = &terminal.arena[id.0 as usize];
-        if skip_char(ch) {
-            continue;
-        }
-        let (lo, hi) = visual_half_range(max_row, ch);
-        min_half = min_half.min(lo);
-        max_half = max_half.max(hi);
-    }
-    let span = max_half - min_half;
-    if span <= 0.0 {
-        return;
-    }
+    let n = (max_row - min_row + 1) as u32;
     let ids: Vec<CharId> = terminal.input_characters.clone();
     for id in ids {
         let ch = &mut terminal.arena[id.0 as usize];
         if skip_char(ch) {
             continue;
         }
-        let (lo, hi) = visual_half_range(max_row, ch);
-        let t = ((lo + hi) * 0.5 - min_half) / span;
-        ch.animation.input_fg_color = Some(palette.color(field_band_index(t)));
+        let i = (max_row - ch.input_coord.row) as u32;
+        ch.animation.input_fg_color = Some(palette.color(field_band_index_n(i, n)));
         ch.uses_input_preexisting_colors = true;
-    }
-}
-
-/// Occupied half-pixel range `[lo, hi)` from the top of the cell grid.
-fn visual_half_range(max_row: i64, ch: &EffectCharacter) -> (f64, f64) {
-    let display_line = (max_row - ch.input_coord.row) as f64;
-    let (lo, hi) = block_half_span(&ch.input_symbol);
-    (display_line * 2.0 + lo, display_line * 2.0 + hi)
-}
-
-/// How much of a terminal cell a glyph inks, in half-pixels from the cell top.
-fn block_half_span(symbol: &str) -> (f64, f64) {
-    match symbol.chars().next().unwrap_or('\0') {
-        '▀' => (0.0, 1.0),
-        '▄' => (1.0, 2.0),
-        _ => (0.0, 2.0),
     }
 }
 
@@ -195,9 +228,26 @@ mod tests {
             .collect();
         by_row.sort_by_key(|(row, _)| std::cmp::Reverse(*row));
 
+        let expected = [0, 0, 0, 0, 1, 1, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4, 4, 4, 4];
+        assert_eq!(by_row.len(), 19);
         for (i, (row, idx)) in by_row.iter().enumerate() {
-            let t = (19.0 - *row as f64 + 0.5) / 19.0;
-            assert_eq!(*idx, field_band_index(t), "row {i} t={t}");
+            assert_eq!(*row, 19 - i as i64);
+            assert_eq!(*idx, expected[i], "row {i}");
+        }
+    }
+
+    #[test]
+    fn discrete_rows_never_drop_a_band() {
+        assert_eq!(field_band_counts(13), vec![3, 1, 3, 2, 4]);
+        assert_eq!(field_band_counts(19), vec![4, 2, 4, 3, 6]);
+        assert_eq!(field_band_counts(10), vec![2, 1, 2, 2, 3]);
+        for n in 5..=40 {
+            let counts = field_band_counts(n);
+            assert_eq!(counts.iter().sum::<u32>(), n, "n={n}");
+            assert!(
+                counts.iter().all(|&c| c >= 1),
+                "n={n} skipped a band: {counts:?}"
+            );
         }
     }
 
@@ -209,12 +259,10 @@ mod tests {
     }
 
     #[test]
-    fn half_blocks_follow_nineteen_pixel_rows() {
+    fn ten_line_word_shows_all_five_stripes() {
         use crate::engine::terminal::{Terminal, TerminalConfig};
         use crate::utils::palette::Palette;
 
-        // Screensaver encoding of the 19-row wordmark: a lower-half peak on
-        // line 0 (the M), then █ = two pixel rows, ▄▀ = one.
         let mut lines = vec!["  ▄  ".to_string(), "▄███▄".to_string()];
         for _ in 0..6 {
             lines.push("█████".to_string());
@@ -235,39 +283,19 @@ mod tests {
         let palette = Palette::from_hex_list("111111,222222,333333,444444,555555").unwrap();
         apply_field_bands(&mut terminal, &palette);
 
-        let mut by_col_row: Vec<(i64, i64, usize, String)> = terminal
+        let mut by_row: Vec<(i64, usize)> = terminal
             .input_characters
             .iter()
-            .map(|&id| {
+            .filter_map(|&id| {
                 let ch = &terminal.arena[id.0 as usize];
-                (
-                    ch.input_coord.column,
-                    ch.input_coord.row,
-                    band_of(ch, &palette),
-                    ch.input_symbol.clone(),
-                )
+                if ch.input_coord.column != 3 {
+                    return None;
+                }
+                Some((ch.input_coord.row, band_of(ch, &palette)))
             })
             .collect();
-        by_col_row.sort_by_key(|&(c, r, _, _)| (c, std::cmp::Reverse(r)));
-
-        // The M peak (top ▄) is crest.
-        let peak_band = by_col_row
-            .iter()
-            .filter(|(_, _, _, s)| s.as_str() == "▄")
-            .max_by_key(|(_, r, _, _)| *r)
-            .unwrap();
-        assert_eq!(peak_band.2, 0, "M peak must be crest, got {peak_band:?}");
-
-        // A letter with no peak: the top-row █ (second input line) is still
-        // crest. Character-row mapping would already have moved it to hover.
-        let body_top = by_col_row
-            .iter()
-            .filter(|(_, _, _, s)| s.as_str() == "█")
-            .max_by_key(|(_, r, _, _)| *r)
-            .unwrap();
-        assert_eq!(
-            body_top.2, 0,
-            "first full body row must stay crest, got {body_top:?}"
-        );
+        by_row.sort_by_key(|(row, _)| std::cmp::Reverse(*row));
+        let bands: Vec<usize> = by_row.into_iter().map(|(_, b)| b).collect();
+        assert_eq!(bands, vec![0, 0, 1, 2, 2, 3, 3, 4, 4, 4]);
     }
 }

--- a/src/utils/bands.rs
+++ b/src/utils/bands.rs
@@ -102,9 +102,10 @@ pub fn field_band_index_n(i: u32, n: u32) -> usize {
 /// Color each input character from the palette by its row in the word.
 ///
 /// `input_coord.row` is 1-based and grows up, so the largest row is the top.
-/// Bands are laid out on whole terminal rows (3-1-3-2-4, largest remainder)
-/// so every stripe is visible. A `█` has one color; measuring in half-pixels
-/// lets the 1-unit hover fall between two cell centers and vanish.
+/// 3-1-3-2-4 is laid out on the *body* rows (lines with at least half the
+/// ink of the densest line). The Omarchy FIGlet's M peak and Y tail are
+/// sparse; counting them in the span stole a crest row, so O/A/R only got
+/// a one-row cap. Sparse rows above the body stay crest; below stay dim.
 pub fn apply_field_bands(terminal: &mut Terminal, palette: &Palette) {
     let mut min_row = i64::MAX;
     let mut max_row = i64::MIN;
@@ -119,15 +120,39 @@ pub fn apply_field_bands(terminal: &mut Terminal, palette: &Palette) {
     if min_row > max_row {
         return;
     }
-    let n = (max_row - min_row + 1) as u32;
+    let n_lines = (max_row - min_row + 1) as usize;
+    let mut ink = vec![0u32; n_lines];
+    for &id in &terminal.input_characters {
+        let ch = &terminal.arena[id.0 as usize];
+        if skip_char(ch) {
+            continue;
+        }
+        ink[(max_row - ch.input_coord.row) as usize] += 1;
+    }
+    let max_ink = ink.iter().copied().max().unwrap_or(0);
+    let threshold = max_ink / 2;
+    let mut body_top = 0usize;
+    let mut body_bot = n_lines.saturating_sub(1);
+    if let Some(top) = ink.iter().position(|&n| n > threshold) {
+        body_top = top;
+        body_bot = ink.iter().rposition(|&n| n > threshold).unwrap_or(top);
+    }
+    let body_n = (body_bot - body_top + 1) as u32;
     let ids: Vec<CharId> = terminal.input_characters.clone();
     for id in ids {
         let ch = &mut terminal.arena[id.0 as usize];
         if skip_char(ch) {
             continue;
         }
-        let i = (max_row - ch.input_coord.row) as u32;
-        ch.animation.input_fg_color = Some(palette.color(field_band_index_n(i, n)));
+        let display = (max_row - ch.input_coord.row) as usize;
+        let band = if display < body_top {
+            0
+        } else if display > body_bot {
+            FIELD_BAND_UNITS.len() - 1
+        } else {
+            field_band_index_n((display - body_top) as u32, body_n)
+        };
+        ch.animation.input_fg_color = Some(palette.color(band));
         ch.uses_input_preexisting_colors = true;
     }
 }
@@ -296,6 +321,8 @@ mod tests {
             .collect();
         by_row.sort_by_key(|(row, _)| std::cmp::Reverse(*row));
         let bands: Vec<usize> = by_row.into_iter().map(|(_, b)| b).collect();
-        assert_eq!(bands, vec![0, 0, 1, 2, 2, 3, 3, 4, 4, 4]);
+        // Sparse peak (row 0) and tail stay crest/dim; 3-1-3-2-4 is 2-1-2-1-2
+        // on the 8 body rows, so the first two full letter rows are crest.
+        assert_eq!(bands, vec![0, 0, 0, 1, 2, 2, 3, 4, 4, 4]);
     }
 }

--- a/src/utils/bands.rs
+++ b/src/utils/bands.rs
@@ -35,32 +35,67 @@ pub fn field_band_index_in(t: f64, units: &[u32]) -> usize {
     units.len() - 1
 }
 
-/// Color each input character from the palette by its row in the word.
+/// Color each input character from the palette by its visual row in the word.
+///
 /// `input_coord.row` is 1-based and grows up, so the largest row is the top.
+/// Half-block art (`▄▀█`) encodes two spec pixels per terminal cell, the way
+/// the 19-row wordmark is stored in the screensaver logo. `t` is measured in
+/// those pixels so a full `█` is two units and a half block is one. Empty
+/// halves (the top of a leading `▄`, the bottom of a trailing `▀`) do not
+/// count, so the M peak cannot steal the crest from the other letters.
 pub fn apply_field_bands(terminal: &mut Terminal, palette: &Palette) {
-    let mut min_row = i64::MAX;
     let mut max_row = i64::MIN;
+    let mut min_half = f64::INFINITY;
+    let mut max_half = f64::NEG_INFINITY;
     for &id in &terminal.input_characters {
         let ch = &terminal.arena[id.0 as usize];
         if skip_char(ch) {
             continue;
         }
-        min_row = min_row.min(ch.input_coord.row);
         max_row = max_row.max(ch.input_coord.row);
     }
-    if min_row > max_row {
+    if max_row == i64::MIN {
         return;
     }
-    let span = (max_row - min_row + 1) as f64;
+    for &id in &terminal.input_characters {
+        let ch = &terminal.arena[id.0 as usize];
+        if skip_char(ch) {
+            continue;
+        }
+        let (lo, hi) = visual_half_range(max_row, ch);
+        min_half = min_half.min(lo);
+        max_half = max_half.max(hi);
+    }
+    let span = max_half - min_half;
+    if span <= 0.0 {
+        return;
+    }
     let ids: Vec<CharId> = terminal.input_characters.clone();
     for id in ids {
         let ch = &mut terminal.arena[id.0 as usize];
         if skip_char(ch) {
             continue;
         }
-        let t = (max_row as f64 - ch.input_coord.row as f64 + 0.5) / span;
+        let (lo, hi) = visual_half_range(max_row, ch);
+        let t = ((lo + hi) * 0.5 - min_half) / span;
         ch.animation.input_fg_color = Some(palette.color(field_band_index(t)));
         ch.uses_input_preexisting_colors = true;
+    }
+}
+
+/// Occupied half-pixel range `[lo, hi)` from the top of the cell grid.
+fn visual_half_range(max_row: i64, ch: &EffectCharacter) -> (f64, f64) {
+    let display_line = (max_row - ch.input_coord.row) as f64;
+    let (lo, hi) = block_half_span(&ch.input_symbol);
+    (display_line * 2.0 + lo, display_line * 2.0 + hi)
+}
+
+/// How much of a terminal cell a glyph inks, in half-pixels from the cell top.
+fn block_half_span(symbol: &str) -> (f64, f64) {
+    match symbol.chars().next().unwrap_or('\0') {
+        '▀' => (0.0, 1.0),
+        '▄' => (1.0, 2.0),
+        _ => (0.0, 2.0),
     }
 }
 
@@ -164,5 +199,75 @@ mod tests {
             let t = (19.0 - *row as f64 + 0.5) / 19.0;
             assert_eq!(*idx, field_band_index(t), "row {i} t={t}");
         }
+    }
+
+    fn band_of(ch: &crate::engine::character::EffectCharacter, palette: &Palette) -> usize {
+        let color = ch.animation.input_fg_color.unwrap();
+        (0..5)
+            .find(|&i| palette.color(i) == color)
+            .expect("palette color")
+    }
+
+    #[test]
+    fn half_blocks_follow_nineteen_pixel_rows() {
+        use crate::engine::terminal::{Terminal, TerminalConfig};
+        use crate::utils::palette::Palette;
+
+        // Screensaver encoding of the 19-row wordmark: a lower-half peak on
+        // line 0 (the M), then █ = two pixel rows, ▄▀ = one.
+        let mut lines = vec!["  ▄  ".to_string(), "▄███▄".to_string()];
+        for _ in 0..6 {
+            lines.push("█████".to_string());
+        }
+        lines.push("▀███▀".to_string());
+        lines.push("  █  ".to_string());
+        let input = lines.join("\n");
+        let mut terminal = Terminal::new(
+            &input,
+            TerminalConfig {
+                canvas_width: 5,
+                canvas_height: 10,
+                ignore_terminal_dimensions: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let palette = Palette::from_hex_list("111111,222222,333333,444444,555555").unwrap();
+        apply_field_bands(&mut terminal, &palette);
+
+        let mut by_col_row: Vec<(i64, i64, usize, String)> = terminal
+            .input_characters
+            .iter()
+            .map(|&id| {
+                let ch = &terminal.arena[id.0 as usize];
+                (
+                    ch.input_coord.column,
+                    ch.input_coord.row,
+                    band_of(ch, &palette),
+                    ch.input_symbol.clone(),
+                )
+            })
+            .collect();
+        by_col_row.sort_by_key(|&(c, r, _, _)| (c, std::cmp::Reverse(r)));
+
+        // The M peak (top ▄) is crest.
+        let peak_band = by_col_row
+            .iter()
+            .filter(|(_, _, _, s)| s.as_str() == "▄")
+            .max_by_key(|(_, r, _, _)| *r)
+            .unwrap();
+        assert_eq!(peak_band.2, 0, "M peak must be crest, got {peak_band:?}");
+
+        // A letter with no peak: the top-row █ (second input line) is still
+        // crest. Character-row mapping would already have moved it to hover.
+        let body_top = by_col_row
+            .iter()
+            .filter(|(_, _, _, s)| s.as_str() == "█")
+            .max_by_key(|(_, r, _, _)| *r)
+            .unwrap();
+        assert_eq!(
+            body_top.2, 0,
+            "first full body row must stay crest, got {body_top:?}"
+        );
     }
 }

--- a/src/utils/bands.rs
+++ b/src/utils/bands.rs
@@ -1,0 +1,168 @@
+//! Vertical field bands on the input word: 3, 1, 3, 2, 4 units crest to dim.
+//!
+//! The spec drawing is 13 units tall. `t` is 0 at the top of the word and 1
+//! at the bottom. Palette color 0 is crest, then hover, lit, mid, dim.
+
+use crate::engine::character::{CharId, EffectCharacter};
+use crate::engine::terminal::Terminal;
+use crate::utils::palette::Palette;
+
+/// Crest, hover, lit, mid, dim — top to bottom.
+pub const FIELD_BAND_UNITS: &[u32] = &[3, 1, 3, 2, 4];
+
+pub fn field_band_rows() -> u32 {
+    FIELD_BAND_UNITS.iter().sum()
+}
+
+/// Which band `t` (0 at the top, 1 at the bottom) falls in.
+pub fn field_band_index(t: f64) -> usize {
+    field_band_index_in(t, FIELD_BAND_UNITS)
+}
+
+pub fn field_band_index_in(t: f64, units: &[u32]) -> usize {
+    let total: u32 = units.iter().copied().sum();
+    if total == 0 || units.is_empty() {
+        return 0;
+    }
+    let u = t.clamp(0.0, 1.0) * total as f64;
+    let mut acc = 0.0;
+    for (i, &n) in units.iter().enumerate() {
+        acc += n as f64;
+        if u < acc {
+            return i;
+        }
+    }
+    units.len() - 1
+}
+
+/// Color each input character from the palette by its row in the word.
+/// `input_coord.row` is 1-based and grows up, so the largest row is the top.
+pub fn apply_field_bands(terminal: &mut Terminal, palette: &Palette) {
+    let mut min_row = i64::MAX;
+    let mut max_row = i64::MIN;
+    for &id in &terminal.input_characters {
+        let ch = &terminal.arena[id.0 as usize];
+        if skip_char(ch) {
+            continue;
+        }
+        min_row = min_row.min(ch.input_coord.row);
+        max_row = max_row.max(ch.input_coord.row);
+    }
+    if min_row > max_row {
+        return;
+    }
+    let span = (max_row - min_row + 1) as f64;
+    let ids: Vec<CharId> = terminal.input_characters.clone();
+    for id in ids {
+        let ch = &mut terminal.arena[id.0 as usize];
+        if skip_char(ch) {
+            continue;
+        }
+        let t = (max_row as f64 - ch.input_coord.row as f64 + 0.5) / span;
+        ch.animation.input_fg_color = Some(palette.color(field_band_index(t)));
+        ch.uses_input_preexisting_colors = true;
+    }
+}
+
+fn skip_char(ch: &EffectCharacter) -> bool {
+    ch.is_fill_character || ch.input_symbol.trim().is_empty()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn spec_units_are_three_one_three_two_four() {
+        assert_eq!(FIELD_BAND_UNITS, &[3, 1, 3, 2, 4]);
+        assert_eq!(field_band_rows(), 13);
+    }
+
+    #[test]
+    fn index_follows_crest_hover_lit_mid_dim() {
+        assert_eq!(field_band_index(0.0), 0);
+        assert_eq!(field_band_index(3.0 / 13.0 - 1e-9), 0);
+        assert_eq!(field_band_index(3.0 / 13.0), 1);
+        assert_eq!(field_band_index(4.0 / 13.0), 2);
+        assert_eq!(field_band_index(7.0 / 13.0), 3);
+        assert_eq!(field_band_index(9.0 / 13.0), 4);
+        assert_eq!(field_band_index(1.0), 4);
+    }
+
+    #[test]
+    fn apply_colors_thirteen_rows_crest_to_dim() {
+        use crate::engine::terminal::{Terminal, TerminalConfig};
+        use crate::utils::palette::Palette;
+
+        let input = ["X"; 13].join("\n");
+        let mut terminal = Terminal::new(
+            &input,
+            TerminalConfig {
+                canvas_width: 1,
+                canvas_height: 13,
+                ignore_terminal_dimensions: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let palette = Palette::from_hex_list("aa0000,00aa00,0000aa,aaaa00,00aaaa").unwrap();
+        apply_field_bands(&mut terminal, &palette);
+
+        let mut by_row: Vec<(i64, crate::utils::graphics::Color)> = terminal
+            .input_characters
+            .iter()
+            .map(|&id| {
+                let ch = &terminal.arena[id.0 as usize];
+                assert!(ch.uses_input_preexisting_colors);
+                (ch.input_coord.row, ch.animation.input_fg_color.unwrap())
+            })
+            .collect();
+        by_row.sort_by_key(|(row, _)| std::cmp::Reverse(*row));
+
+        let expected = [0, 0, 0, 1, 2, 2, 2, 3, 3, 4, 4, 4, 4];
+        assert_eq!(by_row.len(), 13);
+        for (i, (row, color)) in by_row.iter().enumerate() {
+            assert_eq!(*row, 13 - i as i64);
+            assert_eq!(*color, palette.color(expected[i]));
+        }
+    }
+
+    #[test]
+    fn apply_colors_nineteen_rows_keep_unit_proportions() {
+        use crate::engine::terminal::{Terminal, TerminalConfig};
+        use crate::utils::palette::Palette;
+
+        let input = ["X"; 19].join("\n");
+        let mut terminal = Terminal::new(
+            &input,
+            TerminalConfig {
+                canvas_width: 1,
+                canvas_height: 19,
+                ignore_terminal_dimensions: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let palette = Palette::from_hex_list("111111,222222,333333,444444,555555").unwrap();
+        apply_field_bands(&mut terminal, &palette);
+
+        let mut by_row: Vec<(i64, usize)> = terminal
+            .input_characters
+            .iter()
+            .map(|&id| {
+                let ch = &terminal.arena[id.0 as usize];
+                let color = ch.animation.input_fg_color.unwrap();
+                let idx = (0..5)
+                    .find(|&i| palette.color(i) == color)
+                    .expect("palette color");
+                (ch.input_coord.row, idx)
+            })
+            .collect();
+        by_row.sort_by_key(|(row, _)| std::cmp::Reverse(*row));
+
+        for (i, (row, idx)) in by_row.iter().enumerate() {
+            let t = (19.0 - *row as f64 + 0.5) / 19.0;
+            assert_eq!(*idx, field_band_index(t), "row {i} t={t}");
+        }
+    }
+}

--- a/src/utils/bands.rs
+++ b/src/utils/bands.rs
@@ -1,14 +1,14 @@
-//! Vertical field bands on the input word: 3, 1, 3, 2, 4 units crest to dim.
+//! Vertical field bands on the input word: 4, 1, 4, 3, 5 units crest to dim.
 //!
-//! The spec drawing is 13 units tall. `t` is 0 at the top of the word and 1
-//! at the bottom. Palette color 0 is crest, then hover, lit, mid, dim.
+//! The field is 17 units tall. `t` is 0 at the top of the word and 1 at the
+//! bottom. Palette color 0 is crest, then hover, lit, mid, dim.
 
 use crate::engine::character::{CharId, EffectCharacter};
 use crate::engine::terminal::Terminal;
 use crate::utils::palette::Palette;
 
 /// Crest, hover, lit, mid, dim — top to bottom.
-pub const FIELD_BAND_UNITS: &[u32] = &[3, 1, 3, 2, 4];
+pub const FIELD_BAND_UNITS: &[u32] = &[4, 1, 4, 3, 5];
 
 pub fn field_band_rows() -> u32 {
     FIELD_BAND_UNITS.iter().sum()
@@ -102,7 +102,7 @@ pub fn field_band_index_n(i: u32, n: u32) -> usize {
 /// Color each input character from the palette by its row in the word.
 ///
 /// `input_coord.row` is 1-based and grows up, so the largest row is the top.
-/// 3-1-3-2-4 is laid out on the *body* rows (lines with at least half the
+/// 4-1-4-3-5 is laid out on the *body* rows (lines with at least half the
 /// ink of the densest line). The Omarchy FIGlet's M peak and Y tail are
 /// sparse; counting them in the span stole a crest row, so O/A/R only got
 /// a one-row cap. Sparse rows above the body stay crest; below stay dim.
@@ -166,19 +166,19 @@ mod tests {
     use super::*;
 
     #[test]
-    fn spec_units_are_three_one_three_two_four() {
-        assert_eq!(FIELD_BAND_UNITS, &[3, 1, 3, 2, 4]);
-        assert_eq!(field_band_rows(), 13);
+    fn spec_units_are_four_one_four_three_five() {
+        assert_eq!(FIELD_BAND_UNITS, &[4, 1, 4, 3, 5]);
+        assert_eq!(field_band_rows(), 17);
     }
 
     #[test]
     fn index_follows_crest_hover_lit_mid_dim() {
         assert_eq!(field_band_index(0.0), 0);
-        assert_eq!(field_band_index(3.0 / 13.0 - 1e-9), 0);
-        assert_eq!(field_band_index(3.0 / 13.0), 1);
-        assert_eq!(field_band_index(4.0 / 13.0), 2);
-        assert_eq!(field_band_index(7.0 / 13.0), 3);
-        assert_eq!(field_band_index(9.0 / 13.0), 4);
+        assert_eq!(field_band_index(4.0 / 17.0 - 1e-9), 0);
+        assert_eq!(field_band_index(4.0 / 17.0), 1);
+        assert_eq!(field_band_index(5.0 / 17.0), 2);
+        assert_eq!(field_band_index(9.0 / 17.0), 3);
+        assert_eq!(field_band_index(12.0 / 17.0), 4);
         assert_eq!(field_band_index(1.0), 4);
     }
 
@@ -212,6 +212,7 @@ mod tests {
             .collect();
         by_row.sort_by_key(|(row, _)| std::cmp::Reverse(*row));
 
+        // 4-1-4-3-5 on 13 rows is 3-1-3-2-4.
         let expected = [0, 0, 0, 1, 2, 2, 2, 3, 3, 4, 4, 4, 4];
         assert_eq!(by_row.len(), 13);
         for (i, (row, color)) in by_row.iter().enumerate() {
@@ -253,7 +254,7 @@ mod tests {
             .collect();
         by_row.sort_by_key(|(row, _)| std::cmp::Reverse(*row));
 
-        let expected = [0, 0, 0, 0, 1, 1, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4, 4, 4, 4];
+        let expected = [0, 0, 0, 0, 0, 1, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4, 4, 4, 4];
         assert_eq!(by_row.len(), 19);
         for (i, (row, idx)) in by_row.iter().enumerate() {
             assert_eq!(*row, 19 - i as i64);
@@ -263,9 +264,10 @@ mod tests {
 
     #[test]
     fn discrete_rows_never_drop_a_band() {
+        assert_eq!(field_band_counts(17), vec![4, 1, 4, 3, 5]);
         assert_eq!(field_band_counts(13), vec![3, 1, 3, 2, 4]);
-        assert_eq!(field_band_counts(19), vec![4, 2, 4, 3, 6]);
-        assert_eq!(field_band_counts(10), vec![2, 1, 2, 2, 3]);
+        assert_eq!(field_band_counts(19), vec![5, 1, 4, 3, 6]);
+        assert_eq!(field_band_counts(8), vec![2, 1, 2, 1, 2]);
         for n in 5..=40 {
             let counts = field_band_counts(n);
             assert_eq!(counts.iter().sum::<u32>(), n, "n={n}");
@@ -321,7 +323,7 @@ mod tests {
             .collect();
         by_row.sort_by_key(|(row, _)| std::cmp::Reverse(*row));
         let bands: Vec<usize> = by_row.into_iter().map(|(_, b)| b).collect();
-        // Sparse peak (row 0) and tail stay crest/dim; 3-1-3-2-4 is 2-1-2-1-2
+        // Sparse peak (row 0) and tail stay crest/dim; 4-1-4-3-5 is 2-1-2-1-2
         // on the 8 body rows, so the first two full letter rows are crest.
         assert_eq!(bands, vec![0, 0, 0, 1, 2, 2, 3, 4, 4, 4]);
     }

--- a/src/utils/bands.rs
+++ b/src/utils/bands.rs
@@ -1,4 +1,4 @@
-//! Vertical field bands on the input word: 4, 3, 4, 3, 5 units crest to dim.
+//! Vertical field bands on the input word: 5, 2, 4, 3, 5 units crest to dim.
 //!
 //! The field is 19 units tall, one per wordmark bitmap row. `t` is 0 at the
 //! top of the word and 1 at the bottom. Palette color 0 is crest, then hover,
@@ -9,7 +9,7 @@ use crate::engine::terminal::Terminal;
 use crate::utils::palette::Palette;
 
 /// Crest, hover, lit, mid, dim — top to bottom.
-pub const FIELD_BAND_UNITS: &[u32] = &[4, 3, 4, 3, 5];
+pub const FIELD_BAND_UNITS: &[u32] = &[5, 2, 4, 3, 5];
 
 pub fn field_band_rows() -> u32 {
     FIELD_BAND_UNITS.iter().sum()
@@ -37,7 +37,7 @@ pub fn field_band_index_in(t: f64, units: &[u32]) -> usize {
 }
 
 /// How many of `n` discrete rows each band gets. Hamilton / largest remainder
-/// so a 1-unit hover is never dropped when `n` is not a multiple of 13.
+/// so a 1-unit hover is never dropped when `n` is not a multiple of 19.
 pub fn field_band_counts(n: u32) -> Vec<u32> {
     let bands = FIELD_BAND_UNITS.len();
     if n == 0 {
@@ -103,10 +103,9 @@ pub fn field_band_index_n(i: u32, n: u32) -> usize {
 /// Color each input character from the palette by its row in the word.
 ///
 /// `input_coord.row` is 1-based and grows up, so the largest row is the top.
-/// 4-3-4-3-5 is laid out on the *body* rows (lines with at least half the
-/// ink of the densest line). The Omarchy FIGlet's M peak and Y tail are
-/// sparse; counting them in the span stole a crest row, so O/A/R only got
-/// a one-row cap. Sparse rows above the body stay crest; below stay dim.
+/// 5-2-4-3-5 is a ratio: whatever number of lines the file has, those five
+/// bands are spread across them (19 lines stay 5-2-4-3-5; 10 lines become
+/// 3-1-2-1-3).
 pub fn apply_field_bands(terminal: &mut Terminal, palette: &Palette) {
     let mut min_row = i64::MAX;
     let mut max_row = i64::MIN;
@@ -121,38 +120,15 @@ pub fn apply_field_bands(terminal: &mut Terminal, palette: &Palette) {
     if min_row > max_row {
         return;
     }
-    let n_lines = (max_row - min_row + 1) as usize;
-    let mut ink = vec![0u32; n_lines];
-    for &id in &terminal.input_characters {
-        let ch = &terminal.arena[id.0 as usize];
-        if skip_char(ch) {
-            continue;
-        }
-        ink[(max_row - ch.input_coord.row) as usize] += 1;
-    }
-    let max_ink = ink.iter().copied().max().unwrap_or(0);
-    let threshold = max_ink / 2;
-    let mut body_top = 0usize;
-    let mut body_bot = n_lines.saturating_sub(1);
-    if let Some(top) = ink.iter().position(|&n| n > threshold) {
-        body_top = top;
-        body_bot = ink.iter().rposition(|&n| n > threshold).unwrap_or(top);
-    }
-    let body_n = (body_bot - body_top + 1) as u32;
+    let n = (max_row - min_row + 1) as u32;
     let ids: Vec<CharId> = terminal.input_characters.clone();
     for id in ids {
         let ch = &mut terminal.arena[id.0 as usize];
         if skip_char(ch) {
             continue;
         }
-        let display = (max_row - ch.input_coord.row) as usize;
-        let band = if display < body_top {
-            0
-        } else if display > body_bot {
-            FIELD_BAND_UNITS.len() - 1
-        } else {
-            field_band_index_n((display - body_top) as u32, body_n)
-        };
+        let display = (max_row - ch.input_coord.row) as u32;
+        let band = field_band_index_n(display, n);
         ch.animation.input_fg_color = Some(palette.color(band));
         ch.uses_input_preexisting_colors = true;
     }
@@ -167,16 +143,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn spec_units_are_four_three_four_three_five() {
-        assert_eq!(FIELD_BAND_UNITS, &[4, 3, 4, 3, 5]);
+    fn spec_units_are_five_two_four_three_five() {
+        assert_eq!(FIELD_BAND_UNITS, &[5, 2, 4, 3, 5]);
         assert_eq!(field_band_rows(), 19);
     }
 
     #[test]
     fn index_follows_crest_hover_lit_mid_dim() {
         assert_eq!(field_band_index(0.0), 0);
-        assert_eq!(field_band_index(4.0 / 19.0 - 1e-9), 0);
-        assert_eq!(field_band_index(4.0 / 19.0), 1);
+        assert_eq!(field_band_index(5.0 / 19.0 - 1e-9), 0);
+        assert_eq!(field_band_index(5.0 / 19.0), 1);
         assert_eq!(field_band_index(7.0 / 19.0), 2);
         assert_eq!(field_band_index(11.0 / 19.0), 3);
         assert_eq!(field_band_index(14.0 / 19.0), 4);
@@ -213,8 +189,8 @@ mod tests {
             .collect();
         by_row.sort_by_key(|(row, _)| std::cmp::Reverse(*row));
 
-        // 4-3-4-3-5 on 13 rows is 3-2-3-2-3.
-        let expected = [0, 0, 0, 1, 1, 2, 2, 2, 3, 3, 4, 4, 4];
+        // 5-2-4-3-5 on 13 rows is 4-1-3-2-3.
+        let expected = [0, 0, 0, 0, 1, 2, 2, 2, 3, 3, 4, 4, 4];
         assert_eq!(by_row.len(), 13);
         for (i, (row, color)) in by_row.iter().enumerate() {
             assert_eq!(*row, 13 - i as i64);
@@ -255,7 +231,7 @@ mod tests {
             .collect();
         by_row.sort_by_key(|(row, _)| std::cmp::Reverse(*row));
 
-        let expected = [0, 0, 0, 0, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4, 4, 4];
+        let expected = [0, 0, 0, 0, 0, 1, 1, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4, 4, 4];
         assert_eq!(by_row.len(), 19);
         for (i, (row, idx)) in by_row.iter().enumerate() {
             assert_eq!(*row, 19 - i as i64);
@@ -265,8 +241,9 @@ mod tests {
 
     #[test]
     fn discrete_rows_never_drop_a_band() {
-        assert_eq!(field_band_counts(19), vec![4, 3, 4, 3, 5]);
-        assert_eq!(field_band_counts(13), vec![3, 2, 3, 2, 3]);
+        assert_eq!(field_band_counts(19), vec![5, 2, 4, 3, 5]);
+        assert_eq!(field_band_counts(13), vec![4, 1, 3, 2, 3]);
+        assert_eq!(field_band_counts(10), vec![3, 1, 2, 1, 3]);
         assert_eq!(field_band_counts(8), vec![2, 1, 2, 1, 2]);
         for n in 5..=40 {
             let counts = field_band_counts(n);
@@ -286,22 +263,55 @@ mod tests {
     }
 
     #[test]
-    fn ten_line_word_shows_all_five_stripes() {
+    fn ten_rows_scale_five_two_four_three_five() {
         use crate::engine::terminal::{Terminal, TerminalConfig};
         use crate::utils::palette::Palette;
 
-        let mut lines = vec!["  ▄  ".to_string(), "▄███▄".to_string()];
-        for _ in 0..6 {
+        let input = ["X"; 10].join("\n");
+        let mut terminal = Terminal::new(
+            &input,
+            TerminalConfig {
+                canvas_width: 1,
+                canvas_height: 10,
+                ignore_terminal_dimensions: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let palette = Palette::from_hex_list("111111,222222,333333,444444,555555").unwrap();
+        apply_field_bands(&mut terminal, &palette);
+
+        let mut by_row: Vec<(i64, usize)> = terminal
+            .input_characters
+            .iter()
+            .map(|&id| {
+                let ch = &terminal.arena[id.0 as usize];
+                (ch.input_coord.row, band_of(ch, &palette))
+            })
+            .collect();
+        by_row.sort_by_key(|(row, _)| std::cmp::Reverse(*row));
+        let bands: Vec<usize> = by_row.into_iter().map(|(_, b)| b).collect();
+        // 5-2-4-3-5 on 10 rows is 3-1-2-1-3.
+        assert_eq!(bands, vec![0, 0, 0, 1, 2, 2, 3, 4, 4, 4]);
+    }
+
+    #[test]
+    fn nineteen_row_wordmark_keeps_sparse_peak_in_crest() {
+        use crate::engine::terminal::{Terminal, TerminalConfig};
+        use crate::utils::palette::Palette;
+
+        let mut lines = vec!["  █  ".to_string()];
+        for _ in 0..16 {
             lines.push("█████".to_string());
         }
-        lines.push("▀███▀".to_string());
+        lines.push("  █  ".to_string());
         lines.push("  █  ".to_string());
         let input = lines.join("\n");
         let mut terminal = Terminal::new(
             &input,
             TerminalConfig {
                 canvas_width: 5,
-                canvas_height: 10,
+                canvas_height: 19,
                 ignore_terminal_dimensions: true,
                 ..Default::default()
             },
@@ -323,8 +333,9 @@ mod tests {
             .collect();
         by_row.sort_by_key(|(row, _)| std::cmp::Reverse(*row));
         let bands: Vec<usize> = by_row.into_iter().map(|(_, b)| b).collect();
-        // Sparse peak (row 0) and tail stay crest/dim; 4-3-4-3-5 is 2-1-2-1-2
-        // on the 8 body rows, so the first two full letter rows are crest.
-        assert_eq!(bands, vec![0, 0, 0, 1, 2, 2, 3, 4, 4, 4]);
+        assert_eq!(
+            bands,
+            vec![0, 0, 0, 0, 0, 1, 1, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4, 4, 4]
+        );
     }
 }

--- a/src/utils/graphics.rs
+++ b/src/utils/graphics.rs
@@ -152,6 +152,19 @@ impl Color {
         (self.rgb[0], self.rgb[1], self.rgb[2])
     }
 
+    /// RGB constructor used by gradient generation. Same `color_arg` as a
+    /// lowercase hex string, without going through `format!` / `from_hex`.
+    pub fn from_rgb(r: u8, g: u8, b: u8) -> Self {
+        let rgb = [r, g, b];
+        let rgb_color = RgbString::from_rgb(rgb);
+        Color {
+            color_arg: ColorArg::Hex(rgb_color),
+            xterm_color: None,
+            rgb,
+            rgb_color,
+        }
+    }
+
     fn parse_rgb(s: &str) -> [u8; 3] {
         [
             u8::from_str_radix(&s[0..2], 16).unwrap(),
@@ -270,7 +283,7 @@ impl Gradient {
                 let red = (sr + red_delta * i).clamp(0, 255);
                 let green = (sg + green_delta * i).clamp(0, 255);
                 let blue = (sb + blue_delta * i).clamp(0, 255);
-                spectrum.push(Color::from_hex(&format!("{red:02x}{green:02x}{blue:02x}")).unwrap());
+                spectrum.push(Color::from_rgb(red as u8, green as u8, blue as u8));
             }
             spectrum.push(end.clone());
         }
@@ -365,7 +378,8 @@ impl Gradient {
 
 /// graphics.random_color.
 pub fn random_color(rng: &mut Rng) -> Color {
-    Color::from_hex(&format!("{:06x}", rng.randint(0, 0xFFFFFF))).unwrap()
+    let n = rng.randint(0, 0xFFFFFF) as u32;
+    Color::from_rgb(((n >> 16) & 0xff) as u8, ((n >> 8) & 0xff) as u8, (n & 0xff) as u8)
 }
 
 /// graphics.shift_color_towards: float lerp with int() TRUNCATION back to hex

--- a/src/utils/graphics.rs
+++ b/src/utils/graphics.rs
@@ -34,6 +34,18 @@ impl RgbString {
             len: value.len() as u8,
         }
     }
+
+    fn from_rgb([r, g, b]: [u8; 3]) -> Self {
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        let mut bytes = [0; 7];
+        bytes[0] = HEX[(r >> 4) as usize];
+        bytes[1] = HEX[(r & 0x0f) as usize];
+        bytes[2] = HEX[(g >> 4) as usize];
+        bytes[3] = HEX[(g & 0x0f) as usize];
+        bytes[4] = HEX[(b >> 4) as usize];
+        bytes[5] = HEX[(b & 0x0f) as usize];
+        RgbString { bytes, len: 6 }
+    }
 }
 
 impl Deref for RgbString {
@@ -108,12 +120,12 @@ impl std::hash::Hash for Color {
 
 impl Color {
     pub fn from_xterm(code: u8) -> Self {
-        let rgb_color = RgbString::new(hexterm::xterm_to_hex(code));
+        let rgb = hexterm::xterm_rgb(code);
         Color {
             color_arg: ColorArg::Xterm(code),
             xterm_color: Some(code),
-            rgb: Self::parse_rgb(&rgb_color),
-            rgb_color,
+            rgb,
+            rgb_color: RgbString::from_rgb(rgb),
         }
     }
 

--- a/src/utils/graphics.rs
+++ b/src/utils/graphics.rs
@@ -149,6 +149,16 @@ impl Color {
     }
 }
 
+/// argutils.ColorArg: <=3 chars -> xterm int 0-255, else hex.
+pub fn parse_color(s: &str) -> Result<Color, String> {
+    if s.len() <= 3 {
+        let code: u8 = s.parse().map_err(|_| format!("invalid color value: '{s}'"))?;
+        Ok(Color::from_xterm(code))
+    } else {
+        Color::from_hex(s)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub struct ColorPair {
     pub fg_color: Option<Color>,
@@ -378,7 +388,7 @@ pub fn shift_color_towards(color: &Color, target_color: &Color, factor: f64) -> 
 mod tests {
     use std::collections::HashMap;
 
-    use super::Color;
+    use super::{parse_color, Color};
 
     #[test]
     fn rgb_string_borrowed_lookup_matches_str_hash() {
@@ -395,5 +405,12 @@ mod tests {
             format!("{color:?}"),
             "Color { color_arg: Hex(\"12AbEf7\"), xterm_color: None, rgb_color: \"12AbEf7\" }"
         );
+    }
+
+    #[test]
+    fn parse_color_accepts_xterm_codes_and_hex() {
+        assert_eq!(parse_color("255").unwrap(), Color::from_xterm(255));
+        assert_eq!(parse_color("12AbEf").unwrap(), Color::from_hex("12AbEf").unwrap());
+        assert!(parse_color("not-a-color").is_err());
     }
 }

--- a/src/utils/hexterm.rs
+++ b/src/utils/hexterm.rs
@@ -4,16 +4,51 @@
 use std::cell::RefCell;
 #[cfg(not(target_arch = "wasm32"))]
 use std::collections::HashMap;
-#[cfg(not(target_arch = "wasm32"))]
-use std::sync::OnceLock;
-
+#[cfg(any(test, not(target_arch = "wasm32")))]
 include!("hexterm_table.rs");
+
+/// Canonical xterm-256 RGB: 16 VGA colors, a 6³ cube, then 24 grayscale.
+pub(crate) fn xterm_rgb(code: u8) -> [u8; 3] {
+    match code {
+        0..=15 => {
+            const SYSTEM: [[u8; 3]; 16] = [
+                [0x00, 0x00, 0x00],
+                [0x80, 0x00, 0x00],
+                [0x00, 0x80, 0x00],
+                [0x80, 0x80, 0x00],
+                [0x00, 0x00, 0x80],
+                [0x80, 0x00, 0x80],
+                [0x00, 0x80, 0x80],
+                [0xc0, 0xc0, 0xc0],
+                [0x80, 0x80, 0x80],
+                [0xff, 0x00, 0x00],
+                [0x00, 0xff, 0x00],
+                [0xff, 0xff, 0x00],
+                [0x00, 0x00, 0xff],
+                [0xff, 0x00, 0xff],
+                [0x00, 0xff, 0xff],
+                [0xff, 0xff, 0xff],
+            ];
+            SYSTEM[code as usize]
+        }
+        16..=231 => {
+            const LEVELS: [u8; 6] = [0x00, 0x5f, 0x87, 0xaf, 0xd7, 0xff];
+            let i = code - 16;
+            [
+                LEVELS[(i / 36) as usize],
+                LEVELS[((i / 6) % 6) as usize],
+                LEVELS[(i % 6) as usize],
+            ]
+        }
+        232..=255 => {
+            let v = 8 + (code - 232) * 10;
+            [v, v, v]
+        }
+    }
+}
 
 #[cfg(not(target_arch = "wasm32"))]
 type Rgb = [u8; 3];
-
-#[cfg(not(target_arch = "wasm32"))]
-static XTERM_RGB: OnceLock<[Rgb; 256]> = OnceLock::new();
 
 #[cfg(not(target_arch = "wasm32"))]
 thread_local! {
@@ -33,25 +68,19 @@ fn parse_rgb(hex_color: &str) -> Rgb {
     ]
 }
 
-/// Parse the generated palette once rather than reparsing all 768 channels on
-/// every conversion.
-#[cfg(not(target_arch = "wasm32"))]
-fn xterm_rgb() -> &'static [Rgb; 256] {
-    XTERM_RGB.get_or_init(|| std::array::from_fn(|code| parse_rgb(XTERM_TO_HEX[code])))
-}
-
 #[cfg(not(target_arch = "wasm32"))]
 fn closest_xterm([r, g, b]: Rgb) -> u8 {
     let mut min_diff = u16::MAX;
     let mut closest = 0u8;
-    for (code, &[xr, xg, xb]) in xterm_rgb().iter().enumerate() {
+    for code in 0u8..=255 {
+        let [xr, xg, xb] = xterm_rgb(code);
         // Upstream divides this sum by three before comparing it. Division by
         // the same positive constant is order-preserving, so comparing the
         // integer sums retains its strict-first-minimum tie behavior exactly.
         let diff = r.abs_diff(xr) as u16 + g.abs_diff(xg) as u16 + b.abs_diff(xb) as u16;
         if diff < min_diff {
             min_diff = diff;
-            closest = code as u8;
+            closest = code;
         }
     }
     closest
@@ -77,6 +106,9 @@ pub fn hex_to_xterm(hex_color: &str) -> u8 {
 }
 
 /// xterm code -> hex string without leading '#'.
+///
+/// Wasm builds Color RGB from [`xterm_rgb`] instead of this table.
+#[cfg(any(test, not(target_arch = "wasm32")))]
 pub fn xterm_to_hex(xterm_color: u8) -> &'static str {
     XTERM_TO_HEX[xterm_color as usize]
 }
@@ -116,6 +148,13 @@ mod tests {
         assert_eq!(xterm_to_hex(0), "000000");
         assert_eq!(xterm_to_hex(15), "ffffff");
         assert_eq!(xterm_to_hex(196), "ff0000");
+    }
+
+    #[test]
+    fn computed_rgb_matches_hex_table() {
+        for code in 0..=255u8 {
+            assert_eq!(xterm_rgb(code), parse_rgb(XTERM_TO_HEX[code as usize]), "{code}");
+        }
     }
 
     #[test]

--- a/src/utils/hexterm.rs
+++ b/src/utils/hexterm.rs
@@ -1,15 +1,21 @@
 //! xterm-256 <-> RGB conversion, ported from utils/hexterm.py.
 
+#[cfg(not(target_arch = "wasm32"))]
 use std::cell::RefCell;
+#[cfg(not(target_arch = "wasm32"))]
 use std::collections::HashMap;
+#[cfg(not(target_arch = "wasm32"))]
 use std::sync::OnceLock;
 
 include!("hexterm_table.rs");
 
+#[cfg(not(target_arch = "wasm32"))]
 type Rgb = [u8; 3];
 
+#[cfg(not(target_arch = "wasm32"))]
 static XTERM_RGB: OnceLock<[Rgb; 256]> = OnceLock::new();
 
+#[cfg(not(target_arch = "wasm32"))]
 thread_local! {
     /// Scene and Animation both memoize this conversion upstream. Keeping the
     /// memo here also covers callers outside the animation engine and lets all
@@ -17,6 +23,7 @@ thread_local! {
     static HEX_TO_XTERM_CACHE: RefCell<HashMap<u32, u8>> = RefCell::new(HashMap::new());
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn parse_rgb(hex_color: &str) -> Rgb {
     let s = hex_color.trim_matches('#');
     [
@@ -28,10 +35,12 @@ fn parse_rgb(hex_color: &str) -> Rgb {
 
 /// Parse the generated palette once rather than reparsing all 768 channels on
 /// every conversion.
+#[cfg(not(target_arch = "wasm32"))]
 fn xterm_rgb() -> &'static [Rgb; 256] {
     XTERM_RGB.get_or_init(|| std::array::from_fn(|code| parse_rgb(XTERM_TO_HEX[code])))
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn closest_xterm([r, g, b]: Rgb) -> u8 {
     let mut min_diff = u16::MAX;
     let mut closest = 0u8;
@@ -51,6 +60,9 @@ fn closest_xterm([r, g, b]: Rgb) -> u8 {
 /// Closest xterm-256 code by mean absolute channel difference; linear scan over
 /// codes 0..=255 in order, strict `<` so the first minimum wins (upstream
 /// hexterm.py hex_to_xterm).
+///
+/// Wasm packed frames emit 24-bit RGB, so this conversion is native-only.
+#[cfg(not(target_arch = "wasm32"))]
 pub fn hex_to_xterm(hex_color: &str) -> u8 {
     let rgb = parse_rgb(hex_color);
     let key = u32::from_be_bytes([0, rgb[0], rgb[1], rgb[2]]);

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,6 +3,7 @@ pub mod ansi;
 pub mod geometry;
 pub mod graphics;
 pub mod hexterm;
+pub mod palette;
 pub mod pycompat;
 pub mod ordered_map;
 pub mod rng;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,6 @@
 pub mod easing;
 pub mod ansi;
+pub mod bands;
 pub mod geometry;
 pub mod graphics;
 pub mod hexterm;

--- a/src/utils/palette.rs
+++ b/src/utils/palette.rs
@@ -1,0 +1,144 @@
+//! A list of hex colors that replace an effect's default colors.
+
+use std::collections::HashSet;
+
+use clap::parser::ValueSource;
+use clap::ArgMatches;
+
+use crate::utils::graphics::{parse_color, Color};
+
+/// One or more colors used in place of each effect's default color arguments.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Palette {
+    colors: Vec<Color>,
+}
+
+impl Palette {
+    pub fn new(colors: Vec<Color>) -> Result<Self, String> {
+        if colors.is_empty() {
+            Err("palette must contain at least one hex color".to_string())
+        } else {
+            Ok(Palette { colors })
+        }
+    }
+
+    pub fn from_hex_list(s: &str) -> Result<Self, String> {
+        Self::new(parse_palette_arg(s)?)
+    }
+
+    pub fn colors(&self) -> &[Color] {
+        &self.colors
+    }
+
+    pub fn color(&self, index: usize) -> Color {
+        self.colors[index % self.colors.len()]
+    }
+
+    pub fn stops(&self, n: usize) -> Vec<Color> {
+        (0..n).map(|i| self.color(i)).collect()
+    }
+}
+
+/// Split a `--palette` value on commas and whitespace.
+pub fn parse_palette_arg(s: &str) -> Result<Vec<Color>, String> {
+    let mut colors = Vec::new();
+    for part in s.split(|c: char| c == ',' || c.is_whitespace()) {
+        if part.is_empty() {
+            continue;
+        }
+        colors.push(parse_color(part)?);
+    }
+    if colors.is_empty() {
+        Err("palette must contain at least one hex color".to_string())
+    } else {
+        Ok(colors)
+    }
+}
+
+/// Clap ids the user set on the command line (so those color flags stay put).
+pub fn command_line_arg_ids(matches: &ArgMatches) -> HashSet<String> {
+    matches
+        .ids()
+        .filter(|id| matches.value_source(id.as_str()) == Some(ValueSource::CommandLine))
+        .map(|id| id.as_str().to_string())
+        .collect()
+}
+
+pub trait ApplyPalette {
+    fn apply_palette(&mut self, palette: &Palette, skip: &HashSet<String>);
+}
+
+pub trait Recolor {
+    fn recolor(&mut self, palette: &Palette, single_index: &mut usize);
+}
+
+impl Recolor for Color {
+    fn recolor(&mut self, palette: &Palette, single_index: &mut usize) {
+        *self = palette.color(*single_index);
+        *single_index += 1;
+    }
+}
+
+impl Recolor for Vec<Color> {
+    fn recolor(&mut self, palette: &Palette, _single_index: &mut usize) {
+        let n = self.len();
+        if n == 0 {
+            return;
+        }
+        *self = palette.stops(n);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn color(hex: &str) -> Color {
+        parse_color(hex).expect("test hex")
+    }
+
+    #[test]
+    fn parse_palette_arg_splits_commas_whitespace_and_hashes() {
+        assert_eq!(
+            parse_palette_arg("#7aa2f7, c0caf5\tf7768e").unwrap(),
+            vec![color("#7aa2f7"), color("c0caf5"), color("f7768e")]
+        );
+    }
+
+    #[test]
+    fn parse_palette_arg_rejects_empty_and_invalid() {
+        assert!(parse_palette_arg("").is_err());
+        assert!(parse_palette_arg("  ,  ").is_err());
+        assert!(parse_palette_arg("not-a-color").is_err());
+        assert!(parse_palette_arg("ff0000,gg0000").is_err());
+    }
+
+    #[test]
+    fn stops_cycle_when_the_list_is_short() {
+        let palette = Palette::new(vec![color("ff0000"), color("00ff00")]).unwrap();
+        assert_eq!(
+            palette.stops(3),
+            vec![color("ff0000"), color("00ff00"), color("ff0000")]
+        );
+        assert_eq!(palette.stops(1), vec![color("ff0000")]);
+    }
+
+    #[test]
+    fn recolor_lists_use_the_full_palette_and_singles_advance() {
+        let palette = Palette::new(vec![color("ff0000"), color("00ff00")]).unwrap();
+        let mut list = vec![color("111111"), color("222222"), color("333333")];
+        let mut first = color("aaaaaa");
+        let mut second = color("bbbbbb");
+        let mut index = 0usize;
+        list.recolor(&palette, &mut index);
+        first.recolor(&palette, &mut index);
+        second.recolor(&palette, &mut index);
+        assert_eq!(index, 2);
+        assert_eq!(
+            list,
+            vec![color("ff0000"), color("00ff00"), color("ff0000")]
+        );
+        assert_eq!(first, color("ff0000"));
+        assert_eq!(second, color("00ff00"));
+    }
+}

--- a/src/utils/rng.rs
+++ b/src/utils/rng.rs
@@ -27,12 +27,19 @@ impl Rng {
 
     pub fn from_entropy() -> Self {
         let mut buf = [0u8; 8];
-        // /dev/urandom is always present on the Unix targets we support
-        // (Linux and macOS).
-        use std::io::Read;
-        std::fs::File::open("/dev/urandom")
-            .and_then(|mut f| f.read_exact(&mut buf))
-            .expect("failed to read /dev/urandom");
+        #[cfg(target_arch = "wasm32")]
+        {
+            getrandom::getrandom(&mut buf).expect("failed to read entropy");
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            // /dev/urandom is always present on the Unix targets we support
+            // (Linux and macOS).
+            use std::io::Read;
+            std::fs::File::open("/dev/urandom")
+                .and_then(|mut f| f.read_exact(&mut buf))
+                .expect("failed to read /dev/urandom");
+        }
         Rng::seeded(u64::from_le_bytes(buf))
     }
 

--- a/src/utils/rng.rs
+++ b/src/utils/rng.rs
@@ -10,6 +10,25 @@ pub struct Rng {
     s: [u64; 4],
 }
 
+/// Browser CSPRNG without the getrandom crate (its unused-target error
+/// strings were larger than this import).
+#[cfg(target_arch = "wasm32")]
+mod wasm_entropy {
+    use wasm_bindgen::prelude::*;
+
+    #[wasm_bindgen]
+    extern "C" {
+        #[wasm_bindgen(js_namespace = crypto, js_name = getRandomValues)]
+        fn get_random_values(buf: &js_sys::Uint8Array);
+    }
+
+    pub fn fill(buf: &mut [u8]) {
+        let array = js_sys::Uint8Array::new_with_length(buf.len() as u32);
+        get_random_values(&array);
+        array.copy_to(buf);
+    }
+}
+
 impl Rng {
     pub fn seeded(seed: u64) -> Self {
         // SplitMix64 expansion of the seed into the xoshiro state, the
@@ -29,7 +48,7 @@ impl Rng {
         let mut buf = [0u8; 8];
         #[cfg(target_arch = "wasm32")]
         {
-            getrandom::getrandom(&mut buf).expect("failed to read entropy");
+            wasm_entropy::fill(&mut buf);
         }
         #[cfg(not(target_arch = "wasm32"))]
         {

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,0 +1,170 @@
+//! Browser bindings: run any effect against a packed cell frame.
+
+use clap::{CommandFactory, Parser};
+use wasm_bindgen::prelude::*;
+
+use crate::cli::Cli;
+use crate::engine::canvas::Anchor;
+use crate::engine::ctx::{Clock, EngineCtx};
+use crate::engine::effect::Effect;
+use crate::engine::terminal::{PackedFrame, TerminalConfig};
+use crate::utils::graphics::Color;
+use crate::utils::rng::Rng;
+
+#[wasm_bindgen]
+pub struct Session {
+    effect: Box<dyn Effect>,
+    ctx: EngineCtx,
+    frame: PackedFrame,
+    done: bool,
+}
+
+#[wasm_bindgen]
+impl Session {
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        input: &str,
+        effect: &str,
+        columns: u32,
+        rows: u32,
+        seed: Option<f64>,
+        frame_rate: u32,
+    ) -> Result<Session, JsError> {
+        if input.trim().is_empty() {
+            return Err(JsError::new("NO INPUT."));
+        }
+        let columns = columns.max(1) as i64;
+        let rows = rows.max(1) as i64;
+        let frame_rate = frame_rate as i64;
+        let rng = match seed {
+            Some(s) if s.is_finite() => Rng::seeded(s as u64),
+            _ => Rng::from_entropy(),
+        };
+        let config = TerminalConfig {
+            frame_rate,
+            canvas_width: 0,
+            canvas_height: 0,
+            anchor_canvas: Anchor::C,
+            anchor_text: Anchor::C,
+            reuse_canvas: true,
+            no_eol: true,
+            no_restore_cursor: true,
+            terminal_background_color: Color::from_hex("000000").unwrap(),
+            terminal_size: Some((columns, rows)),
+            ..TerminalConfig::default()
+        };
+        let clock = Clock::virtual_with_frame_rate(if frame_rate > 0 { frame_rate } else { 60 });
+        let mut ctx = EngineCtx::new(input, config, rng, clock).map_err(|e| JsError::new(&e.to_string()))?;
+        let mut effect = build_effect(effect)?;
+        effect.build(&mut ctx).map_err(|e| JsError::new(&e.to_string()))?;
+        Ok(Session {
+            effect,
+            ctx,
+            frame: PackedFrame {
+                width: 0,
+                height: 0,
+                symbols: String::new(),
+                fg: Vec::new(),
+                bg: Vec::new(),
+                flags: Vec::new(),
+            },
+            done: false,
+        })
+    }
+
+    /// Advance one animation frame. Returns false when the effect is finished.
+    pub fn step(&mut self) -> bool {
+        if self.done {
+            return false;
+        }
+        match self.effect.next_frame(&mut self.ctx) {
+            Some(output) => {
+                self.ctx.terminal.recycle_output_string(output);
+                self.frame = self.ctx.terminal.pack_display_frame();
+                true
+            }
+            None => {
+                self.done = true;
+                false
+            }
+        }
+    }
+
+    pub fn done(&self) -> bool {
+        self.done
+    }
+
+    pub fn width(&self) -> u32 {
+        self.frame.width as u32
+    }
+
+    pub fn height(&self) -> u32 {
+        self.frame.height as u32
+    }
+
+    pub fn symbols(&self) -> String {
+        self.frame.symbols.clone()
+    }
+
+    pub fn fg(&self) -> Vec<u32> {
+        self.frame.fg.clone()
+    }
+
+    pub fn bg(&self) -> Vec<u32> {
+        self.frame.bg.clone()
+    }
+
+    pub fn flags(&self) -> Vec<u8> {
+        self.frame.flags.clone()
+    }
+}
+
+fn build_effect(name: &str) -> Result<Box<dyn Effect>, JsError> {
+    match Cli::try_parse_from(["ttfx", name]) {
+        Ok(Cli { effect: Some(effect), .. }) => Ok(effect.build_effect()),
+        Ok(_) => Err(JsError::new(&format!("unknown effect '{name}'"))),
+        Err(e) => Err(JsError::new(&format!("unknown effect '{name}': {e}"))),
+    }
+}
+
+/// JSON array of `{name, about}` for every registered effect.
+#[wasm_bindgen]
+pub fn effect_catalog() -> String {
+    let mut out = String::from("[");
+    for (i, cmd) in Cli::command().get_subcommands().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        out.push_str("{\"name\":");
+        json_string(&mut out, cmd.get_name());
+        out.push_str(",\"about\":");
+        json_string(
+            &mut out,
+            cmd.get_about().map(|s| s.to_string()).unwrap_or_default().as_str(),
+        );
+        out.push('}');
+    }
+    out.push(']');
+    out
+}
+
+fn json_string(out: &mut String, value: &str) {
+    out.push('"');
+    for ch in value.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if c.is_control() => {
+                out.push_str("\\u");
+                let code = c as u32;
+                let hex = format!("{code:04x}");
+                out.push_str(&hex);
+            }
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+}

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -77,8 +77,7 @@ impl Session {
             return false;
         }
         match self.effect.next_frame(&mut self.ctx) {
-            Some(output) => {
-                self.ctx.terminal.recycle_output_string(output);
+            Some(_output) => {
                 self.frame = self.ctx.terminal.pack_display_frame();
                 true
             }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -169,7 +169,7 @@ fn build_effect(name: &str, palette: Option<&Palette>) -> Result<Box<dyn Effect>
         .ok_or_else(|| JsError::new(&format!("unknown effect '{name}'")))
 }
 
-/// Which 3-1-3-2-4 band `t` (0 at the top, 1 at the bottom) falls in.
+/// Which 4-1-4-3-5 band `t` (0 at the top, 1 at the bottom) falls in.
 #[wasm_bindgen]
 pub fn field_band_index(t: f64) -> u32 {
     crate::utils::bands::field_band_index(t) as u32

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,6 +1,6 @@
 //! Browser bindings: run any effect against a packed cell frame.
 
-use js_sys::{Uint8Array, Uint32Array};
+use js_sys::{Uint32Array, Uint8Array};
 use wasm_bindgen::prelude::*;
 
 use crate::engine::canvas::Anchor;
@@ -8,6 +8,7 @@ use crate::engine::ctx::{Clock, EngineCtx};
 use crate::engine::effect::Effect;
 use crate::engine::terminal::{PackedFrame, TerminalConfig};
 use crate::utils::graphics::Color;
+use crate::utils::palette::Palette;
 use crate::utils::rng::Rng;
 
 #[wasm_bindgen]
@@ -28,6 +29,7 @@ impl Session {
         rows: u32,
         seed: Option<f64>,
         frame_rate: u32,
+        palette: Option<String>,
     ) -> Result<Session, JsError> {
         if input.trim().is_empty() {
             return Err(JsError::new("NO INPUT."));
@@ -53,9 +55,16 @@ impl Session {
             ..TerminalConfig::default()
         };
         let clock = Clock::virtual_with_frame_rate(if frame_rate > 0 { frame_rate } else { 60 });
-        let mut ctx = EngineCtx::new(input, config, rng, clock).map_err(|e| JsError::new(&e.to_string()))?;
-        let mut effect = build_effect(effect)?;
-        effect.build(&mut ctx).map_err(|e| JsError::new(&e.to_string()))?;
+        let mut ctx =
+            EngineCtx::new(input, config, rng, clock).map_err(|e| JsError::new(&e.to_string()))?;
+        let palette = match palette.as_deref() {
+            Some(s) => Some(Palette::from_hex_list(s).map_err(|e| JsError::new(&e))?),
+            None => None,
+        };
+        let mut effect = build_effect(effect, palette.as_ref())?;
+        effect
+            .build(&mut ctx)
+            .map_err(|e| JsError::new(&e.to_string()))?;
         Ok(Session {
             effect,
             ctx,
@@ -138,8 +147,8 @@ impl Session {
     }
 }
 
-fn build_effect(name: &str) -> Result<Box<dyn Effect>, JsError> {
-    crate::effects::build_named_effect(name)
+fn build_effect(name: &str, palette: Option<&Palette>) -> Result<Box<dyn Effect>, JsError> {
+    crate::effects::build_named_effect_with_palette(name, palette)
         .ok_or_else(|| JsError::new(&format!("unknown effect '{name}'")))
 }
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -169,7 +169,7 @@ fn build_effect(name: &str, palette: Option<&Palette>) -> Result<Box<dyn Effect>
         .ok_or_else(|| JsError::new(&format!("unknown effect '{name}'")))
 }
 
-/// Which 4-3-4-3-5 band `t` (0 at the top, 1 at the bottom) falls in.
+/// Which 5-2-4-3-5 band `t` (0 at the top, 1 at the bottom) falls in.
 #[wasm_bindgen]
 pub fn field_band_index(t: f64) -> u32 {
     crate::utils::bands::field_band_index(t) as u32

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -169,7 +169,7 @@ fn build_effect(name: &str, palette: Option<&Palette>) -> Result<Box<dyn Effect>
         .ok_or_else(|| JsError::new(&format!("unknown effect '{name}'")))
 }
 
-/// Which 4-1-4-3-5 band `t` (0 at the top, 1 at the bottom) falls in.
+/// Which 4-3-4-3-5 band `t` (0 at the top, 1 at the bottom) falls in.
 #[wasm_bindgen]
 pub fn field_band_index(t: f64) -> u32 {
     crate::utils::bands::field_band_index(t) as u32

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,10 +1,8 @@
 //! Browser bindings: run any effect against a packed cell frame.
 
-use clap::{CommandFactory, Parser};
 use js_sys::{Uint8Array, Uint32Array};
 use wasm_bindgen::prelude::*;
 
-use crate::cli::Cli;
 use crate::engine::canvas::Anchor;
 use crate::engine::ctx::{Clock, EngineCtx};
 use crate::engine::effect::Effect;
@@ -142,28 +140,22 @@ impl Session {
 }
 
 fn build_effect(name: &str) -> Result<Box<dyn Effect>, JsError> {
-    match Cli::try_parse_from(["ttfx", name]) {
-        Ok(Cli { effect: Some(effect), .. }) => Ok(effect.build_effect()),
-        Ok(_) => Err(JsError::new(&format!("unknown effect '{name}'"))),
-        Err(e) => Err(JsError::new(&format!("unknown effect '{name}': {e}"))),
-    }
+    crate::effects::build_named_effect(name)
+        .ok_or_else(|| JsError::new(&format!("unknown effect '{name}'")))
 }
 
 /// JSON array of `{name, about}` for every registered effect.
 #[wasm_bindgen]
 pub fn effect_catalog() -> String {
     let mut out = String::from("[");
-    for (i, cmd) in Cli::command().get_subcommands().enumerate() {
+    for (i, (name, about)) in crate::effects::catalog_entries().iter().enumerate() {
         if i > 0 {
             out.push(',');
         }
         out.push_str("{\"name\":");
-        json_string(&mut out, cmd.get_name());
+        json_string(&mut out, name);
         out.push_str(",\"about\":");
-        json_string(
-            &mut out,
-            cmd.get_about().map(|s| s.to_string()).unwrap_or_default().as_str(),
-        );
+        json_string(&mut out, about);
         out.push('}');
     }
     out.push(']');

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -31,6 +31,7 @@ impl Session {
         frame_rate: u32,
         palette: Option<String>,
         background: Option<String>,
+        bands: Option<bool>,
     ) -> Result<Session, JsError> {
         if input.trim().is_empty() {
             return Err(JsError::new("NO INPUT."));
@@ -56,6 +57,11 @@ impl Session {
                 None => Color::from_hex("000000").unwrap(),
             },
             terminal_size: Some((columns, rows)),
+            existing_color_handling: if bands.unwrap_or(false) {
+                crate::engine::animation::ExistingColorHandling::Always
+            } else {
+                crate::engine::animation::ExistingColorHandling::Ignore
+            },
             ..TerminalConfig::default()
         };
         let clock = Clock::virtual_with_frame_rate(if frame_rate > 0 { frame_rate } else { 60 });
@@ -65,6 +71,13 @@ impl Session {
             Some(s) => Some(Palette::from_hex_list(s).map_err(|e| JsError::new(&e))?),
             None => None,
         };
+        if bands.unwrap_or(false) {
+            let Some(palette) = palette.as_ref() else {
+                return Err(JsError::new("--bands requires a palette"));
+            };
+            crate::utils::bands::apply_field_bands(&mut ctx.terminal, palette);
+            ctx.preexisting_colors_present = true;
+        }
         let mut effect = build_effect(effect, palette.as_ref())?;
         effect
             .build(&mut ctx)
@@ -154,6 +167,12 @@ impl Session {
 fn build_effect(name: &str, palette: Option<&Palette>) -> Result<Box<dyn Effect>, JsError> {
     crate::effects::build_named_effect_with_palette(name, palette)
         .ok_or_else(|| JsError::new(&format!("unknown effect '{name}'")))
+}
+
+/// Which 3-1-3-2-4 band `t` (0 at the top, 1 at the bottom) falls in.
+#[wasm_bindgen]
+pub fn field_band_index(t: f64) -> u32 {
+    crate::utils::bands::field_band_index(t) as u32
 }
 
 /// JSON array of `{name, about}` for every registered effect.

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -30,6 +30,7 @@ impl Session {
         seed: Option<f64>,
         frame_rate: u32,
         palette: Option<String>,
+        background: Option<String>,
     ) -> Result<Session, JsError> {
         if input.trim().is_empty() {
             return Err(JsError::new("NO INPUT."));
@@ -50,7 +51,10 @@ impl Session {
             reuse_canvas: true,
             no_eol: true,
             no_restore_cursor: true,
-            terminal_background_color: Color::from_hex("000000").unwrap(),
+            terminal_background_color: match background.as_deref() {
+                Some(hex) => Color::from_hex(hex).map_err(|e| JsError::new(&e))?,
+                None => Color::from_hex("000000").unwrap(),
+            },
             terminal_size: Some((columns, rows)),
             ..TerminalConfig::default()
         };

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,6 +1,7 @@
 //! Browser bindings: run any effect against a packed cell frame.
 
 use clap::{CommandFactory, Parser};
+use js_sys::{Uint8Array, Uint32Array};
 use wasm_bindgen::prelude::*;
 
 use crate::cli::Cli;
@@ -63,7 +64,7 @@ impl Session {
             frame: PackedFrame {
                 width: 0,
                 height: 0,
-                symbols: String::new(),
+                symbols: Vec::new(),
                 fg: Vec::new(),
                 bg: Vec::new(),
                 flags: Vec::new(),
@@ -102,20 +103,41 @@ impl Session {
         self.frame.height as u32
     }
 
-    pub fn symbols(&self) -> String {
-        self.frame.symbols.clone()
-    }
-
-    pub fn fg(&self) -> Vec<u32> {
-        self.frame.fg.clone()
-    }
-
-    pub fn bg(&self) -> Vec<u32> {
-        self.frame.bg.clone()
-    }
-
-    pub fn flags(&self) -> Vec<u8> {
-        self.frame.flags.clone()
+    /// Copy the current frame into caller-owned typed arrays.
+    ///
+    /// Each array must be at least `width * height` long. Extra length is left
+    /// untouched. Symbols are Unicode scalar values, one per cell.
+    pub fn fill(
+        &self,
+        symbols: &Uint32Array,
+        fg: &Uint32Array,
+        bg: &Uint32Array,
+        flags: &Uint8Array,
+    ) -> Result<(), JsError> {
+        let n = self.frame.cell_count();
+        if (symbols.length() as usize) < n
+            || (fg.length() as usize) < n
+            || (bg.length() as usize) < n
+            || (flags.length() as usize) < n
+        {
+            return Err(JsError::new("frame buffers are too small"));
+        }
+        if n == 0 {
+            return Ok(());
+        }
+        if self.frame.symbols.len() != n
+            || self.frame.fg.len() != n
+            || self.frame.bg.len() != n
+            || self.frame.flags.len() != n
+        {
+            return Err(JsError::new("packed frame is truncated"));
+        }
+        let end = n as u32;
+        symbols.subarray(0, end).copy_from(&self.frame.symbols);
+        fg.subarray(0, end).copy_from(&self.frame.fg);
+        bg.subarray(0, end).copy_from(&self.frame.bg);
+        flags.subarray(0, end).copy_from(&self.frame.flags);
+        Ok(())
     }
 }
 

--- a/tests/ctx_frame.rs
+++ b/tests/ctx_frame.rs
@@ -1,0 +1,38 @@
+use ttfx::engine::ctx::{Clock, EngineCtx};
+use ttfx::engine::terminal::TerminalConfig;
+use ttfx::utils::rng::Rng;
+
+fn visible_ctx(input: &str) -> EngineCtx {
+    let config = TerminalConfig {
+        canvas_width: 3,
+        canvas_height: 1,
+        ignore_terminal_dimensions: true,
+        frame_rate: 0,
+        ..Default::default()
+    };
+    let mut ctx = EngineCtx::new(input, config, Rng::seeded(0), Clock::virtual_with_frame_rate(60))
+        .unwrap();
+    let ids = ctx.terminal.input_characters.clone();
+    for id in ids {
+        ctx.terminal.set_character_visibility(id, true);
+    }
+    ctx
+}
+
+#[test]
+fn frame_emits_ansi_for_the_cli() {
+    let mut ctx = visible_ctx("A");
+    let out = ctx.frame();
+    assert!(
+        out.contains('A'),
+        "cli frames should still format ANSI, got {out:?}"
+    );
+}
+
+#[test]
+fn frame_advances_virtual_clock() {
+    let mut ctx = visible_ctx("A");
+    let before = ctx.clock.now_monotonic();
+    let _ = ctx.frame();
+    assert!(ctx.clock.now_monotonic() > before);
+}

--- a/tests/packed_frame.rs
+++ b/tests/packed_frame.rs
@@ -1,0 +1,50 @@
+use ttfx::engine::terminal::{PackedFrame, Terminal, TerminalConfig};
+
+#[test]
+fn pack_display_frame_puts_the_top_row_first() {
+    let mut terminal = Terminal::new(
+        "AB",
+        TerminalConfig {
+            canvas_width: 2,
+            canvas_height: 1,
+            ignore_terminal_dimensions: true,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let ids = terminal.input_characters.clone();
+    for id in ids {
+        terminal.set_character_visibility(id, true);
+    }
+    let packed = terminal.pack_display_frame();
+    assert_eq!(packed.width, 2);
+    assert_eq!(packed.height, 1);
+    assert_eq!(packed.symbols, "AB");
+    assert_eq!(packed.fg.len(), 2);
+    assert_eq!(packed.bg.len(), 2);
+    assert_eq!(packed.flags.len(), 2);
+}
+
+#[test]
+fn pack_display_frame_empty_cells_are_spaces() {
+    let mut terminal = Terminal::new(
+        "A",
+        TerminalConfig {
+            canvas_width: 3,
+            canvas_height: 1,
+            ignore_terminal_dimensions: true,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let ids = terminal.input_characters.clone();
+    for id in ids {
+        terminal.set_character_visibility(id, true);
+    }
+    let packed = terminal.pack_display_frame();
+    assert_eq!(packed.width, 3);
+    assert_eq!(packed.symbols.chars().count(), 3);
+    assert!(packed.symbols.contains('A'));
+    assert!(packed.symbols.contains(' '));
+    let _ = PackedFrame::BOLD;
+}

--- a/tests/packed_frame.rs
+++ b/tests/packed_frame.rs
@@ -1,12 +1,15 @@
 use ttfx::engine::terminal::{PackedFrame, Terminal, TerminalConfig};
 
-#[test]
-fn pack_display_frame_puts_the_top_row_first() {
+const SPACE: u32 = b' ' as u32;
+const A: u32 = b'A' as u32;
+const B: u32 = b'B' as u32;
+
+fn visible_terminal(input: &str, width: i64, height: i64) -> Terminal {
     let mut terminal = Terminal::new(
-        "AB",
+        input,
         TerminalConfig {
-            canvas_width: 2,
-            canvas_height: 1,
+            canvas_width: width,
+            canvas_height: height,
             ignore_terminal_dimensions: true,
             ..Default::default()
         },
@@ -16,10 +19,15 @@ fn pack_display_frame_puts_the_top_row_first() {
     for id in ids {
         terminal.set_character_visibility(id, true);
     }
-    let packed = terminal.pack_display_frame();
+    terminal
+}
+
+#[test]
+fn pack_display_frame_puts_the_top_row_first() {
+    let packed = visible_terminal("AB", 2, 1).pack_display_frame();
     assert_eq!(packed.width, 2);
     assert_eq!(packed.height, 1);
-    assert_eq!(packed.symbols, "AB");
+    assert_eq!(packed.symbols, vec![A, B]);
     assert_eq!(packed.fg.len(), 2);
     assert_eq!(packed.bg.len(), 2);
     assert_eq!(packed.flags.len(), 2);
@@ -27,24 +35,44 @@ fn pack_display_frame_puts_the_top_row_first() {
 
 #[test]
 fn pack_display_frame_empty_cells_are_spaces() {
-    let mut terminal = Terminal::new(
-        "A",
-        TerminalConfig {
-            canvas_width: 3,
-            canvas_height: 1,
-            ignore_terminal_dimensions: true,
-            ..Default::default()
-        },
-    )
-    .unwrap();
-    let ids = terminal.input_characters.clone();
-    for id in ids {
-        terminal.set_character_visibility(id, true);
-    }
-    let packed = terminal.pack_display_frame();
+    let packed = visible_terminal("A", 3, 1).pack_display_frame();
     assert_eq!(packed.width, 3);
-    assert_eq!(packed.symbols.chars().count(), 3);
-    assert!(packed.symbols.contains('A'));
-    assert!(packed.symbols.contains(' '));
+    assert_eq!(packed.symbols.len(), 3);
+    assert!(packed.symbols.contains(&A));
+    assert!(packed.symbols.contains(&SPACE));
     let _ = PackedFrame::BOLD;
+}
+
+#[test]
+fn packed_frame_fill_copies_into_caller_buffers() {
+    let packed = visible_terminal("AB", 2, 1).pack_display_frame();
+    let mut symbols = [0u32; 4];
+    let mut fg = [7u32; 4];
+    let mut bg = [8u32; 4];
+    let mut flags = [9u8; 4];
+    assert_eq!(
+        packed.fill(&mut symbols, &mut fg, &mut bg, &mut flags),
+        Ok(2)
+    );
+    assert_eq!(&symbols[..2], packed.symbols.as_slice());
+    assert_eq!(&fg[..2], packed.fg.as_slice());
+    assert_eq!(&bg[..2], packed.bg.as_slice());
+    assert_eq!(&flags[..2], packed.flags.as_slice());
+    assert_eq!(symbols[2], 0);
+    assert_eq!(fg[2], 7);
+    assert_eq!(bg[2], 8);
+    assert_eq!(flags[2], 9);
+}
+
+#[test]
+fn packed_frame_fill_rejects_short_buffers() {
+    let packed = visible_terminal("AB", 2, 1).pack_display_frame();
+    let mut symbols = [0u32; 1];
+    let mut fg = [0u32; 2];
+    let mut bg = [0u32; 2];
+    let mut flags = [0u8; 2];
+    assert_eq!(
+        packed.fill(&mut symbols, &mut fg, &mut bg, &mut flags),
+        Err("frame buffers are too small")
+    );
 }

--- a/tools/tests/cli_corpus.sh
+++ b/tools/tests/cli_corpus.sh
@@ -44,6 +44,8 @@ grep -qi "unsupported ansi" /tmp/claude-cli-err && pass=$((pass+1)) || { fail=$(
 check success 0 bash -c "printf 'hi' | $RUST --parity-dump --seed 1 --max-frames 5 wipe"
 check success-negative-canvas 0 bash -c "printf 'hi' | $RUST --canvas-width -1 --parity-dump --seed 1 --max-frames 2 wipe"
 check success-multi-stops 0 bash -c "printf 'hi' | $RUST --parity-dump --seed 1 --max-frames 2 wipe --final-gradient-stops ff0000 00ff00 0000ff"
+check success-palette 0 bash -c "printf 'hi' | $RUST --palette ff0000,00ff00 --parity-dump --seed 1 --max-frames 2 wipe"
+check bad-palette 2 bash -c "printf x | $RUST --palette not-a-color wipe"
 
 echo "cli corpus: $pass passed, $fail failed"
 if [ $fail -gt 0 ]; then printf 'FAILED: %s\n' "${failed[@]}"; exit 1; fi


### PR DESCRIPTION
## Summary

Adds a wasm `Session`, hex `--palette`, and `--bands` so WTE, omarchy.org, and the Omarchy screensaver can share one engine.

- Wasm `Session`: packed frames into caller-owned buffers, optional palette string, terminal background, ninth `bands` argument
- CLI `--palette HEX[,HEX...]` replaces each effect's default colors
- CLI `--bands` colors the input word in five field stripes: crest, hover, lit, mid, dim at **4, 3, 4, 3, 5** (19 units, one per wordmark bitmap row). Layout uses dense body rows so a FIGlet peak does not steal the crest. Requires `--palette`. Sets existing-color handling to `always` so every effect settles on those stripes
- 19-line input stays 4-3-4-3-5; other heights use a Hamilton split of that ratio (10 lines become 2-2-2-1-3)
- Per-effect cargo features (`--no-default-features --features decrypt`) and wasm-only skips so a browser build stays small

v0.3.2 has none of `--palette` / `--bands`.

## Test plan

- [x] `cargo test --lib bands`
- [ ] `ttfx --help` shows `--palette` and `--bands`
- [ ] `ttfx -i logo.txt --palette '#daecc6,#bbdd97,#9ece6a,#678549,#39482e' --terminal-background-color '#0e0e14' --bands decrypt`